### PR TITLE
Preallocate sparse-mat Hamiltonians. Remove NumberOp.

### DIFF
--- a/include/mastereq.hpp
+++ b/include/mastereq.hpp
@@ -17,6 +17,7 @@ typedef struct {
   std::vector<double> xi;
   std::vector<double> detuning_freq;
   std::vector<double> collapse_time;
+  bool addT1, addT2;
   std::vector<double> control_Re, control_Im;
   Mat** Ac_vec;
   Mat** Bc_vec;
@@ -54,6 +55,7 @@ class MasterEq{
     std::vector<double> xi;             // Constants for frequencies of drift Hamiltonian
     std::vector<double> detuning_freq;  // detuning frequencies of drift Hamiltonian
     std::vector<double> collapse_time;  // Time-constants for decay and dephase operators
+    bool addT1, addT2;                  // flags for including Lindblad collapse operators T1-decay and/or T2-dephasing
 
     /* Auxiliary stuff */
     int mpirank_petsc;   // Rank of Petsc's communicator
@@ -76,7 +78,7 @@ class MasterEq{
     ~MasterEq();
 
     /* initialize matrices needed for applying sparse-mat solver */
-    void initSparseMatSolver(LindbladType lindbladtype);
+    void initSparseMatSolver();
 
     /* Return the i-th oscillator */
     Oscillator* getOscillator(const int i);

--- a/include/oscillator.hpp
+++ b/include/oscillator.hpp
@@ -20,21 +20,18 @@ struct PiPulse {
 
 class Oscillator {
   protected:
-    int nlevels;                   // Number of levels for this the oscillator 
     double ground_freq;            // Ground frequency of this oscillator
     std::vector<double> params;    // control parameters 
     double Tfinal;                 // final time
     ControlBasis *basisfunctions;  // Control discretization using Bsplines + carrier waves
-    Mat NumberOP;                  // Stores the number operator
-    Mat LoweringOP;                // Stores the lowering operator
-    int dim_preOsc;                // Dimension of coupled subsystems preceding this oscillator
-    int dim_postOsc;               // Dimension of coupled subsystem following this oscillator
 
-    Mat zeromat;                   // auxiliary matrix with zero entries
     int mpirank_petsc;             // rank of Petsc's communicator
 
   public:
     PiPulse pipulse;  // Store a dummy pipulse that does nothing
+    int nlevels;                   // Number of levels for this the oscillator 
+    int dim_preOsc;                // Dimension of coupled subsystems preceding this oscillator
+    int dim_postOsc;               // Dimension of coupled subsystem following this oscillator
 
 
   public:
@@ -48,16 +45,6 @@ class Oscillator {
 
     /* Copy x into the control parameter vector */
     void setParams(const double* x);
-
-    /* Compute lowering operator a_k = I_n1 \kron ... \kron a^(nk) \kron ... \kron I_nQ */
-    int createLoweringOP(const int dim_prekron, const int dim_postkron, Mat* loweringOP);
-    /* Returns the lowering operator, unless dummy is true, then return a zero matrix */
-    Mat getLoweringOP(bool dummy);
-
-    /* Compute number operator N_k = a_k^T a_k */
-    int createNumberOP(const int dim_prekron, const int dim_postcron, Mat* numberOP);
-    /* Returns the number operator, unless dummy is true, then return a zero matrix */
-    Mat getNumberOP(bool dummy);
 
     /* Evaluates rotating frame control functions Re = p(t), Im = q(t) */
     int evalControl(const double t, double* Re_ptr, double* Im_ptr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -382,10 +382,12 @@ int main(int argc,char **argv)
 
   /* Average fidelity */
   double F_avg = 1. - optimctx->obj_cost;
-  printf("F_avg = %f \n", F_avg);
-  if (optimctx->initcond_type != BASIS ||
-      optimctx->objective_type != GATE_TRACE) {
-    printf("Warning: Average gate fidelity only defined for gates using trace distance, and using a basis of initial conditions.\n Recomupte the average fidelity if needed, using all basis elements as initial conditions, and setting GATE_TRACE as objective function.\n");
+  if (mpirank_world == 0){
+    printf("F_avg = %f \n", F_avg);
+    if (optimctx->initcond_type != BASIS ||
+        optimctx->objective_type != GATE_TRACE) {
+      printf("Warning: Average gate fidelity only defined for gates using trace distance, and using a basis of initial conditions.\n Recomupte the average fidelity if needed, using all basis elements as initial conditions, and setting GATE_TRACE as objective function.\n");
+    }
   }
 
   /* --- Finalize --- */

--- a/src/oscillator.cpp
+++ b/src/oscillator.cpp
@@ -18,109 +18,33 @@ Oscillator::Oscillator(int id, std::vector<int> nlevels_all_, int nbasis_, doubl
   /* Create control basis functions */
   basisfunctions = new ControlBasis(nbasis_, Tfinal_, carrier_freq_);
 
-  /* Create and store the number and lowering operators */
+  /* Initialize control parameters */
+  int nparam = 2 * nbasis_ * carrier_freq_.size();
+  for (int i=0; i<nparam; i++) {
+    params.push_back(0.0);
+  }
+
+  /* Compute and store dimension of preceding and following oscillators */
   dim_preOsc = 1;
   dim_postOsc = 1;
   for (int j=0; j<nlevels_all_.size(); j++) {
     if (j < id) dim_preOsc  *= nlevels_all_[j];
     if (j > id) dim_postOsc *= nlevels_all_[j];
   }
-  createNumberOP(dim_preOsc, dim_postOsc, &NumberOP);
-  createLoweringOP(dim_preOsc, dim_postOsc, &LoweringOP);
 
-  /* Create a zero matrix. Used in parallel computation */
-  int dim = dim_preOsc * nlevels * dim_postOsc;
-  MatCreateSeqAIJ(PETSC_COMM_SELF, dim, dim, 0, NULL, &zeromat);
-  MatSetUp(zeromat);
-  MatSetFromOptions(zeromat);
-  MatAssemblyBegin(zeromat, MAT_FINAL_ASSEMBLY);
-  MatAssemblyEnd(zeromat, MAT_FINAL_ASSEMBLY);
- 
-  /* Initialize control parameters */
-  int nparam = 2 * nbasis_ * carrier_freq_.size();
-  for (int i=0; i<nparam; i++) {
-    params.push_back(0.0);
-  }
 }
 
 
 Oscillator::~Oscillator(){
   if (params.size() > 0) {
     delete basisfunctions;
-    MatDestroy(&NumberOP);
-    MatDestroy(&LoweringOP);
-    MatDestroy(&zeromat);
   }
 }
-
-Mat Oscillator::getNumberOP(bool dummy) {
-  if (dummy) return zeromat;
-  else return NumberOP;
-}
-
-Mat Oscillator::getLoweringOP(bool dummy) {
-  if (dummy) return zeromat;
-  else return LoweringOP;
-}
-
 
 void Oscillator::setParams(const double* x){
   for (int i=0; i<params.size(); i++) {
     params[i] = x[i]; 
   }
-}
-
-
-int Oscillator::createNumberOP(const int dim_prekron, const int dim_postkron, Mat* numberOP) {
-
-  int dim_number = dim_prekron*nlevels*dim_postkron;
-
-  /* Create and set number operator */
-  MatCreateSeqAIJ(PETSC_COMM_SELF, dim_number, dim_number, 1, NULL, numberOP);
-  MatSetUp(*numberOP);
-  MatSetFromOptions(*numberOP);
-  for (int i=0; i<dim_prekron; i++) {
-    for (int j=0; j<nlevels; j++) {
-      double val = j;
-      for (int k=0; k<dim_postkron; k++) {
-        int row = i * nlevels*dim_postkron + j * dim_postkron + k;
-        int col = row;
-        MatSetValue(*numberOP, row, col, val, INSERT_VALUES);
-      }
-    }
-  }
-  MatAssemblyBegin(*numberOP, MAT_FINAL_ASSEMBLY);
-  MatAssemblyEnd(*numberOP, MAT_FINAL_ASSEMBLY);
-
-  return dim_number;
-}
-
-
-
-int Oscillator::createLoweringOP(int dim_prekron, int dim_postkron, Mat* loweringOP) {
-
-  int dim_lowering = dim_prekron*nlevels*dim_postkron;
-
-  /* create and set lowering operator */
-  MatCreateSeqAIJ(PETSC_COMM_SELF, dim_lowering, dim_lowering, 1, NULL, loweringOP);
-  MatSetUp(*loweringOP);
-  MatSetFromOptions(*loweringOP);
-  if (mpirank_petsc == 0) {
-    for (int i=0; i<dim_prekron; i++) {
-      for (int j=0; j<nlevels-1; j++) {
-        double val = sqrt(j+1);
-        for (int k=0; k<dim_postkron; k++) {
-          int row = i * nlevels*dim_postkron + j * dim_postkron + k;
-          int col = row + dim_postkron;
-          MatSetValue(*loweringOP, row, col, val, INSERT_VALUES);
-        }
-      }
-    }
-  }
-  MatAssemblyBegin(*loweringOP, MAT_FINAL_ASSEMBLY);
-  MatAssemblyEnd(*loweringOP, MAT_FINAL_ASSEMBLY);
-
-  return dim_lowering;
 }
 
 
@@ -208,9 +132,10 @@ int Oscillator::evalControl_Labframe(const double t, double* f){
 
 double Oscillator::expectedEnergy(const Vec x) {
  
-  int dimmat;
-  MatGetSize(NumberOP, &dimmat, NULL);
-  double xdiag, num_diag;
+  double xdiag;
+  int dim;
+  VecGetSize(x, &dim);
+  int dimmat = (int) sqrt(dim/2);
 
   /* Get locally owned portion of x */
   int ilow, iupp;
@@ -221,7 +146,8 @@ double Oscillator::expectedEnergy(const Vec x) {
   // YC: for-loop below can iterate only for ilow <= 2 * (i * dimmat + i) < iupp
   for (int i=0; i<dimmat; i++) {
     /* Get diagonal element in number operator */
-    MatGetValue(NumberOP, i, i, &num_diag);
+    int num_diag = i % (nlevels*dim_postOsc);
+    num_diag = num_diag / dim_postOsc;
     /* Get diagonal element in rho (real) */
     int idx_diag = i * dimmat + i;
     idx_diag = 2*idx_diag;
@@ -239,8 +165,9 @@ double Oscillator::expectedEnergy(const Vec x) {
 
 
 void Oscillator::expectedEnergy_diff(const Vec x, Vec x_bar, const double obj_bar) {
-  int dimmat;
-  MatGetSize(NumberOP, &dimmat, NULL);
+  int dim;
+  VecGetSize(x, &dim);
+  int dimmat = (int) sqrt(dim/2);
   double num_diag;
 
   /* Get locally owned portion of x */
@@ -249,7 +176,8 @@ void Oscillator::expectedEnergy_diff(const Vec x, Vec x_bar, const double obj_ba
 
   /* Derivative of projective measure */
   for (int i=0; i<dimmat; i++) {
-    MatGetValue(NumberOP, i, i, &num_diag);
+    int num_diag = i % (nlevels*dim_postOsc);
+    num_diag = num_diag / dim_postOsc;
     int idx_diag = getIndexReal(getVecID(i, i, dimmat));
     double val = num_diag * obj_bar;
     if (ilow < idx_diag && idx_diag < iupp) VecSetValues(x_bar, 1, &idx_diag, &val, ADD_VALUES);


### PR DESCRIPTION
For efficiency, preallocate system matrices Ad,Bd,Ac,Bc in sparse-matrix
solver.
Remove explicit setup of NumberOperator and LoweringOperator. Set values
in the system matrix building blocks from paper-pen matrices.

The following commits have been squashed:
Print system dimensions in mastereq constructor.
Set up Bd from pen and paper.
Set control hamiltonian building blocks from pen and paper.
Adding decay and dephasing
Clean up. Don't add zero to mat.
Add Bc_vec.
Remove numberOperator and LoweringOperator.
Preallocate Hamiltonian matrices in sparse-mat solver.
Bugfix for preallocation.
Move check for lindblad options out of oscillator loop.
Create MPIAIJ mats even when on one processor.
Revert "Don't compute objectiveT. Don't write controls."
This reverts commit cc3900f5906fcc998c6a7b930616ecf09b811704.
Bugfix in expectedEnergy objective function.
Move flag for T1/T2 collapse terms to mastereq constructor.