### PR TITLE
initial condition gradient with implicit midpoint rule.

### DIFF
--- a/include/optimproblem.hpp
+++ b/include/optimproblem.hpp
@@ -41,8 +41,10 @@ class OptimProblem {
   bool quietmode;
 
   /* Optimization stuff */
+  bool compute_icgrad;             // flag to compute initial condition gradient
   std::vector<double> obj_weights; /* List of weights for weighting the average objective over initial conditions  */
   int ndesign;                     /* Number of global design parameters */
+  int ncontrol;                    /* Number of global control design parameters */
   double objective;                /* Holds current objective function value */
   double obj_cost;                 /* Final-time term J(T) in objective */
   double obj_regul;                /* Regularization term in objective */
@@ -110,6 +112,11 @@ class OptimProblem {
 
   /* Call this after TaoSolve() has finished to print out some information */
   void getSolution(Vec* opt);
+
+  private:
+
+  void shiftInitialCondition(const Vec &x, const int &iinit_global, Vec &rho_t0_);
+  void gatherICGradient(const Vec &icgrad, const int &iinit_global, Vec &x);
 };
 
 /* Monitor the optimization progress. This routine is called in each iteration of TaoSolve() */

--- a/results/swap02/swap02.cfg
+++ b/results/swap02/swap02.cfg
@@ -120,6 +120,8 @@ output_frequency = 1
 optim_monitor_frequency = 1
 // Runtype options: "simulation" - runs a forward simulation only, "gradient" - forward simulation and gradient computation, or "optimization" - run an optimization
 runtype = optimization
+verify_grad = false
+initial_condition_gradient = false
 // Use matrix free solver, instead of sparse matrix implementation. Only available for 2,3,4, or 5 oscillators. 
 usematfree = true
 // Solver type for solving the linear system at each time step, eighter 'gmres' for using Petscs GMRES solver (preferred), or 'neumann' for using Neumann series iterations


### PR DESCRIPTION
Derived and implemented the gradient for initial condition for implicit midpoint rule. It should involve only one matrix multiplication at the last adjoint time step.

**NOTE:** this should only serve as a kernel, which we can use for intermediate condition gradient in the future. In order to verify the initial condition adjoint, some auxiliary components are added in the code, though they are temporary features that will be removed/changed as we implement the parallel-in-time optimization.

# Core part
- `TimeStepper::evolveBWD` now has an option of computing initial condition gradient.
  - Currently implemented only for `ImplMidPoint`
  - The flag `compute_icgrad_` is supposed to be turned on only at the last adjoint time step.
- For `RunType::GRADIENT`, it is possible to verify the gradient with the input option `verify_grad`. In essence, it repeats finite-difference approximation to check if the relative error minimum is $\sim10^{-8}$.

# Auxiliary, temporary part
- `OptimProblem::ndesign` is the number of control design variable plus the size of the initial condition. This will need to be changed as we have multiple time segments.
- `OptimProblem::evalF` can shift the initial conditions with part of design parameter vector `Vec x`. Likewise, `OptimProblem::evalGradF` can evaluate the gradient of the corresponding part.
  - This part will change as we implement multiple time segments.