### PR TITLE
Unitarity enforcement option for intermediate condition.

### DIFF
--- a/include/optimproblem.hpp
+++ b/include/optimproblem.hpp
@@ -30,7 +30,6 @@ class OptimProblem {
   std::vector<int> initcond_IDs;         /* Integer list for pure-state initialization */
   std::vector<Vec> store_finalstates;    /* Storage for last time steps for each initial condition */
 
-  bool unitarize_interm_ic;               /* Switch to unitarize intermediate initial conditions at evalF/evalGradF */
   std::vector<std::vector<Vec>> store_interm_states;    /* Storage for last time steps of each local time window for each initial condition */
   std::vector<std::vector<Vec>> store_interm_ic;    /* Storage for unitarized intermediate condition of each local time window for each initial condition */
 
@@ -98,6 +97,7 @@ class OptimProblem {
     Vec xinit;                       /* Storing initial design vector, if gamma_tik_interpolate=true, aka if tikhonov is ||x - x_0||^2 rather than ||x||^2 */
     Vec *lambda;                     /* Pointer to lagrange multiplier, not owned by OptimProblem. TODO. */
     double mu;                       /* Penalty strength to intermediate state discontinuities */
+    bool unitarize_interm_ic;               /* Switch to unitarize intermediate initial conditions at evalF/evalGradF */
 
   /* Constructor */
   OptimProblem(MapParam config, TimeStepper* timestepper_, MPI_Comm comm_init_, MPI_Comm comm_time, int ninit_, int nwindows_, double total_time, std::vector<double> gate_rot_freq, Output* output_, bool quietmode=false);

--- a/include/optimproblem.hpp
+++ b/include/optimproblem.hpp
@@ -30,6 +30,7 @@ class OptimProblem {
   std::vector<int> initcond_IDs;         /* Integer list for pure-state initialization */
   std::vector<Vec> store_finalstates;    /* Storage for last time steps for each initial condition */
   std::vector<std::vector<Vec>> store_interm_states;    /* Storage for last time steps of each local time window for each initial condition */
+  std::vector<std::vector<Vec>> store_interm_ic;    /* Storage for unitarized intermediate condition of each local time window for each initial condition */
 
   OptimTarget* optim_target;      /* Storing the optimization goal */
 

--- a/include/optimproblem.hpp
+++ b/include/optimproblem.hpp
@@ -29,6 +29,8 @@ class OptimProblem {
   InitialConditionType initcond_type;    /* Type of initial conditions */
   std::vector<int> initcond_IDs;         /* Integer list for pure-state initialization */
   std::vector<Vec> store_finalstates;    /* Storage for last time steps for each initial condition */
+
+  bool unitarize_interm_ic;               /* Switch to unitarize intermediate initial conditions at evalF/evalGradF */
   std::vector<std::vector<Vec>> store_interm_states;    /* Storage for last time steps of each local time window for each initial condition */
   std::vector<std::vector<Vec>> store_interm_ic;    /* Storage for unitarized intermediate condition of each local time window for each initial condition */
 
@@ -143,6 +145,9 @@ class OptimProblem {
 
   /* Call this after TaoSolve() has finished to print out some information */
   void getSolution(Vec* opt);
+
+  /* Prepare intermediate conditions needed from the optimization variable. If unitarize_interm_ic, unitarize them before using. */
+  void prepareIntermediateCondition(const Vec x, std::vector<std::vector<double>> &vnorms);
 };
 
 /* Monitor the optimization progress. This routine is called in each iteration of TaoSolve() */

--- a/include/optimproblem.hpp
+++ b/include/optimproblem.hpp
@@ -30,8 +30,8 @@ class OptimProblem {
   std::vector<int> initcond_IDs;         /* Integer list for pure-state initialization */
   std::vector<Vec> store_finalstates;    /* Storage for last time steps for each initial condition */
 
-  std::vector<std::vector<Vec>> store_interm_states;    /* Storage for last time steps of each local time window for each initial condition */
-  std::vector<std::vector<Vec>> store_interm_ic;    /* Storage for unitarized intermediate condition of each local time window for each initial condition */
+  std::vector<std::vector<Vec>> final_win_state;    /* Storage for last time steps of each local time window for each initial condition */
+  std::vector<std::vector<Vec>> initial_win_state;    /* Storage for unitarized intermediate condition of each local time window for each initial condition */
 
   OptimTarget* optim_target;      /* Storing the optimization goal */
 

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -108,6 +108,7 @@ void copyLast(std::vector<Tval>& fillme, int tosize){
 };
 
 // TODO(kevin): need to figure out how to parallelize these.
+bool isUnitary(const Vec &x, const std::vector<IS> &IS_interm_states, const int &ninit, const int &nwindows);
 void complex_inner_product(const Vec &x, const Vec &y, double &re, double &im);
 void unitarize(const Vec &x, const std::vector<IS> &IS_interm_states, std::vector<std::vector<Vec>> &interm_ic, std::vector<std::vector<double>> &vnorms);
 void unitarize_grad(const Vec &x, const std::vector<IS> &IS_interm_states, const std::vector<std::vector<Vec>> &interm_ic, const std::vector<std::vector<double>> &vnorms, Vec &G);

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -109,5 +109,5 @@ void copyLast(std::vector<Tval>& fillme, int tosize){
 
 // TODO(kevin): need to figure out how to parallelize these.
 Vec complex_inner_product(const Vec &x, const Vec &y);
-void unitarize(const Vec &x, const std::vector<IS> &IS_interm_states, std::vector<std::vector<Vec>> &interm_ic);
-void unitarize_grad(const Vec &x, const std::vector<IS> &IS_interm_states, const std::vector<std::vector<Vec>> &interm_ic, Vec &G);
+void unitarize(const Vec &x, const std::vector<IS> &IS_interm_states, std::vector<std::vector<Vec>> &interm_ic, std::vector<std::vector<double>> &vnorms);
+void unitarize_grad(const Vec &x, const std::vector<IS> &IS_interm_states, const std::vector<std::vector<Vec>> &interm_ic, const std::vector<std::vector<double>> &vnorms, Vec &G);

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -108,6 +108,6 @@ void copyLast(std::vector<Tval>& fillme, int tosize){
 };
 
 // TODO(kevin): need to figure out how to parallelize these.
-Vec complex_inner_product(const Vec &x, const Vec &y);
+void complex_inner_product(const Vec &x, const Vec &y, double &re, double &im);
 void unitarize(const Vec &x, const std::vector<IS> &IS_interm_states, std::vector<std::vector<Vec>> &interm_ic, std::vector<std::vector<double>> &vnorms);
 void unitarize_grad(const Vec &x, const std::vector<IS> &IS_interm_states, const std::vector<std::vector<Vec>> &interm_ic, const std::vector<std::vector<double>> &vnorms, Vec &G);

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -106,3 +106,8 @@ void copyLast(std::vector<Tval>& fillme, int tosize){
       // std::cout<<std::endl;
     // }
 };
+
+// TODO(kevin): need to figure out how to parallelize these.
+Vec complex_inner_product(const Vec &x, const Vec &y);
+void unitarize(const Vec &x, const std::vector<IS> &IS_interm_states, std::vector<std::vector<Vec>> &interm_ic);
+void unitarize_grad(const Vec &x, const std::vector<IS> &IS_interm_states, const std::vector<std::vector<Vec>> &interm_ic, Vec &G);

--- a/results/gate_swap02/swap02.cfg
+++ b/results/gate_swap02/swap02.cfg
@@ -110,6 +110,7 @@ optim_regul_tik0=false
 optim_mu = 1.0e-3
 load_optimvar=false
 update_lagrangian=false
+optim_unitarize_interm_ic=true
 
 ######################
 # Output and runtypes
@@ -129,7 +130,7 @@ output_frequency = 1
 optim_monitor_frequency = 1
 // Runtype options: "simulation" - runs a forward simulation only, "gradient" - forward simulation and gradient computation, or "optimization" - run an optimization
 runtype = optimization
-verify_grad = false
+verify_grad = true
 // Use matrix free solver, instead of sparse matrix implementation. Only available for 2,3,4, or 5 oscillators. 
 usematfree = true
 // Solver type for solving the linear system at each time step, eighter 'gmres' for using Petscs GMRES solver (preferred), or 'neumann' for using Neumann series iterations

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -666,6 +666,8 @@ int main(int argc,char **argv)
     optimctx->rollOut(opt); // overwrite the intermediate initial conds in 'opt'
 
     // evaluate the fidelity and infidelity with evalF()
+    /* turn off unitarization for rolling out. */
+    optimctx->unitarize_interm_ic = false;
     double final_obj = optimctx->evalF(opt, lambda);
     if (mpirank_world == 0) {
       printf("Final fidelity: %e\n", optimctx->getFidelity());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -616,6 +616,8 @@ int main(int argc,char **argv)
         for (int k = 0; k < Nk; k++)
           printf("%.4E\t%.4E\t%.4E\t%.4E\n", amp[k], obj1[k], dJdx[k], error[k]);
       }
+
+      VecDestroy(&xperturb);
     }
   }
 
@@ -967,6 +969,10 @@ int main(int argc,char **argv)
   delete mytimestepper;
   delete optimctx;
   delete output;
+
+  VecDestroy(&xinit);
+  VecDestroy(&grad);
+  VecDestroy(&lambda);
 
 
   /* Finallize Petsc */

--- a/src/optimproblem.cpp
+++ b/src/optimproblem.cpp
@@ -1118,6 +1118,7 @@ void OptimProblem::rollOut(Vec x){
     } // end for iwindow
   } // end for initial condition
 
+  // bool is_unitary = isUnitary(x, IS_interm_states, ninit, nwindows);
 }
 
 /* lag += - prev_mu * ( S(u_{i-1}) - u_i ) */

--- a/src/optimproblem.cpp
+++ b/src/optimproblem.cpp
@@ -72,17 +72,15 @@ OptimProblem::OptimProblem(MapParam config, TimeStepper* timestepper_, MPI_Comm 
     store_interm_ic[i][index] is the unitarized ic of (index+1)-th global time window, for i-th global initial condition.
     (index = 0, 1, ..., nwindows-2)
   */
-  if (unitarize_interm_ic) {
-    store_interm_ic.resize(ninit);
-    for (int i = 0; i < ninit; i++) {
-      store_interm_ic[i].clear();
-      for (int iwindow = 0; iwindow < nwindows-1; iwindow++) {
-        Vec state;
-        VecCreate(PETSC_COMM_WORLD, &state);
-        VecSetSizes(state, PETSC_DECIDE, 2*timestepper->mastereq->getDim());
-        VecSetFromOptions(state);
-        store_interm_ic[i].push_back(state);
-      }
+  store_interm_ic.resize(ninit);
+  for (int i = 0; i < ninit; i++) {
+    store_interm_ic[i].clear();
+    for (int iwindow = 0; iwindow < nwindows-1; iwindow++) {
+      Vec state;
+      VecCreate(PETSC_COMM_WORLD, &state);
+      VecSetSizes(state, PETSC_DECIDE, 2*timestepper->mastereq->getDim());
+      VecSetFromOptions(state);
+      store_interm_ic[i].push_back(state);
     }
   }
 
@@ -989,7 +987,8 @@ void OptimProblem::evalGradF(const Vec x, const Vec lambda_, Vec G){
 
           int id = iinit_global*(nwindows-1) + index;
           Vec xnext, lag;
-          VecGetSubVector(x, IS_interm_states[id], &xnext);
+          xnext = store_interm_ic[iinit_global][index];
+          // VecGetSubVector(x, IS_interm_states[id], &xnext);
           VecGetSubVector(lambda_, IS_interm_lambda[id], &lag);
           VecAXPY(disc, -1.0, xnext);  // finalstate = S(u_{i-1}) - u_i
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,5 +1,5 @@
 #include "util.hpp"
-
+#include <assert.h>
 
 double sigmoid(double width, double x){
   return 1.0 / ( 1.0 + exp(-width*x) );
@@ -647,4 +647,163 @@ bool isUnitary(const Mat V_re, const Mat V_im){
   MatDestroy(&D);
 
   return isunitary;
+}
+
+void complex_inner_product(const Vec &x, const Vec &y, double &re, double &im) {
+  PetscInt dim2, dummy;
+  VecGetSize(x, &dim2);
+  VecGetSize(y, &dummy);
+  assert(dim2 == dummy);
+  assert(dim2 % 2 == 0);
+
+  PetscInt dim = dim2 / 2;
+  PetscScalar *xptr, *yptr;
+  VecGetArray(x, &xptr);
+  VecGetArray(y, &yptr);
+
+  re = 0.0; im = 0.0;
+  for (int d = 0; d < dim; d++)
+  {
+    // Re[x dot conj(y)] = Re[x] * Re[y] + Im[x] * Im[y]
+    re += xptr[d] * yptr[d] + xptr[d + dim] * yptr[d + dim];
+    // Im[x dot conj(y)] = Im[x] * Re[y] - Re[x] * Im[y]
+    im += xptr[d + dim] * yptr[d] - xptr[d] * yptr[d + dim];
+  }
+  
+  VecRestoreArray(x, &xptr);
+  VecRestoreArray(y, &yptr);
+
+  return;
+}
+
+void unitarize(const Vec &x, const std::vector<IS> &IS_interm_states, std::vector<std::vector<Vec>> &interm_ic, std::vector<std::vector<double>> &vnorms) {
+  Vec v = NULL;
+  VecGetSubVector(x, IS_interm_states[0], &v);
+  PetscInt dim2, dim;
+  VecGetSize(v, &dim2);
+  assert(dim2 % 2 == 0);
+  dim = dim2 / 2;
+
+  // IS IS_re, IS_im;
+  // ISCreateStride(PETSC_COMM_WORLD, dim, 0, 1, &IS_re);
+  // ISCreateStride(PETSC_COMM_WORLD, dim, dim, 1, &IS_im);
+
+  const int ninit = interm_ic.size();
+  const int nwindows = interm_ic[0].size() + 1;
+  vnorms.resize(ninit);
+  for (int iinit = 0; iinit < ninit; iinit++)
+    vnorms[iinit].resize(nwindows-1);
+  
+  PetscScalar *uptr, *vptr;
+  double vu_re, vu_im, vnorm;
+  for (int iwindow = 0; iwindow < nwindows-1; iwindow++) {
+    for (int iinit = 0; iinit < ninit; iinit++) {
+      int idxi = iinit * (nwindows - 1) + iwindow;
+      VecGetSubVector(x, IS_interm_states[idxi], &interm_ic[iinit][iwindow]);
+
+      for (int jinit = 0; jinit < iinit; jinit++) {
+        complex_inner_product(interm_ic[iinit][iwindow], interm_ic[jinit][iwindow], vu_re, vu_im);
+
+        VecGetArray(interm_ic[jinit][iwindow], &uptr);
+        VecGetArray(interm_ic[iinit][iwindow], &vptr);
+        for (int d = 0; d < dim; d++) {
+          vptr[d] -= vu_re * uptr[d] - vu_im * uptr[d + dim];
+          vptr[d + dim] -= vu_re * uptr[d + dim] + vu_im * uptr[d];
+        }
+        VecRestoreArray(interm_ic[jinit][iwindow], &uptr);
+        VecRestoreArray(interm_ic[iinit][iwindow], &vptr);
+      }
+
+      VecNorm(interm_ic[iinit][iwindow], NORM_2, &vnorm);
+      VecScale(interm_ic[iinit][iwindow], 1.0 / vnorm);
+
+      vnorms[iinit][iwindow] = vnorm;
+    }
+  }
+
+  // ISDestroy(&IS_re);
+  // ISDestroy(&IS_im);
+}
+
+void unitarize_grad(const Vec &x, const std::vector<IS> &IS_interm_states, const std::vector<std::vector<Vec>> &interm_ic, const std::vector<std::vector<double>> &vnorms, Vec &G) {
+  Vec w = NULL;
+  VecGetSubVector(x, IS_interm_states[0], &w);
+  PetscInt dim2, dim;
+  VecGetSize(w, &dim2);
+  assert(dim2 % 2 == 0);
+  dim = dim2 / 2;
+
+  const int ninit = interm_ic.size();
+  const int nwindows = interm_ic[0].size() + 1;
+
+  std::vector<Vec> vs(0);
+  for (int k = 0; k < ninit; k++) {
+    Vec state;
+    VecCreate(PETSC_COMM_WORLD, &state);
+    VecSetSizes(state, PETSC_DECIDE, dim2);
+    VecSetFromOptions(state);
+    vs.push_back(state);
+  }
+  
+  Vec us = NULL, ws = NULL;
+  PetscScalar *wptr, *vsptr, *usptr, *uptr;
+  double wu_re, wu_im, vsu_re, vsu_im;
+  for (int iwindow = 0; iwindow < nwindows-1; iwindow++) {
+    for (int iinit = ninit-1; iinit >= 0; iinit--) {
+      int idxi = iinit * (nwindows - 1) + iwindow;
+      VecGetSubVector(G, IS_interm_states[idxi], &us);
+
+      for (int cinit = iinit+1; cinit < ninit; cinit++) {
+        int idxc = cinit * (nwindows - 1) + iwindow;
+        VecGetSubVector(x, IS_interm_states[idxc], &w);
+        complex_inner_product(w, interm_ic[iinit][iwindow], wu_re, wu_im);
+        complex_inner_product(vs[cinit], interm_ic[iinit][iwindow], vsu_re, vsu_im);
+
+        VecGetArray(us, &usptr);
+        VecGetArray(w, &wptr);
+        VecGetArray(vs[cinit], &vsptr);
+        for (int d = 0; d < dim; d++) {
+          usptr[d] -= wu_re * vsptr[d] + wu_im * vsptr[d + dim] + vsu_re * wptr[d] + vsu_im * wptr[d + dim];
+          usptr[d + dim] -= -wu_im * vsptr[d] + wu_im * vsptr[d + dim] - vsu_im * wptr[d] + vsu_re * wptr[d + dim];
+        }
+        VecRestoreArray(us, &usptr);
+        VecRestoreArray(w, &wptr);
+        VecRestoreArray(vs[cinit], &vsptr);
+      }
+
+      double vnorm = vnorms[iinit][iwindow];
+      double usu, dummy;
+      complex_inner_product(us, interm_ic[iinit][iwindow], usu, dummy);
+      VecGetArray(us, &usptr);
+      VecGetArray(vs[iinit], &vsptr);
+      VecGetArray(interm_ic[iinit][iwindow], &uptr);
+      for (int d = 0; d < dim; d++) {
+        vsptr[d] = 1.0 / vnorm * (usptr[d] - usu * uptr[d]);
+        vsptr[d + dim] = 1.0 / vnorm * (usptr[d + dim] - usu * uptr[d + dim]);
+      }
+      VecRestoreArray(us, &usptr);
+      VecRestoreArray(vs[iinit], &vsptr);
+      VecRestoreArray(interm_ic[iinit][iwindow], &uptr);
+
+      VecCopy(vs[iinit], ws);
+      for (int cinit = 0; cinit < iinit; cinit++) {
+        complex_inner_product(vs[iinit], interm_ic[cinit][iwindow], vsu_re, vsu_im);
+
+        VecGetArray(ws, &wptr);
+        VecGetArray(interm_ic[cinit][iwindow], &uptr);
+        for (int d = 0; d < dim; d++) {
+          wptr[d] -= vsu_re * uptr[d] - vsu_im * uptr[d + dim];
+          wptr[d + dim] -= vsu_im * uptr[d] + vsu_re * uptr[d + dim];
+        }
+        VecRestoreArray(ws, &wptr);
+        VecRestoreArray(interm_ic[cinit][iwindow], &uptr);
+      }
+
+      VecISCopy(G, IS_interm_states[idxi], SCATTER_FORWARD, ws);
+    }
+  }
+
+  for (int k = 0; k < ninit; k++) {
+    VecDestroy(&(vs[k]));
+  }
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -780,6 +780,7 @@ void unitarize(const Vec &x, const std::vector<IS> &IS_interm_states, std::vecto
   VecGetSize(v, &dim2);
   assert(dim2 % 2 == 0);
   dim = dim2 / 2;
+  VecRestoreSubVector(x, IS_interm_states[0], &v);
 
   IS IS_re, IS_im;
   ISCreateStride(PETSC_COMM_WORLD, dim, 0, 2, &IS_re);
@@ -871,6 +872,7 @@ void unitarize_grad(const Vec &x, const std::vector<IS> &IS_interm_states, const
   VecGetSize(w, &dim2);
   assert(dim2 % 2 == 0);
   dim = dim2 / 2;
+  VecRestoreSubVector(x, IS_interm_states[0], &w);
 
   IS IS_re, IS_im;
   ISCreateStride(PETSC_COMM_WORLD, dim, 0, 2, &IS_re);
@@ -898,7 +900,6 @@ void unitarize_grad(const Vec &x, const std::vector<IS> &IS_interm_states, const
   
   Vec wre, wim, vsre, vsim, ure, uim;
   double wu_re, wu_im, vsu_re, vsu_im;
-  int dreal, dimag;
   for (int iwindow = 0; iwindow < nwindows-1; iwindow++) {
     for (int iinit = ninit-1; iinit >= 0; iinit--) {
       int idxi = iinit * (nwindows - 1) + iwindow;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -866,7 +866,7 @@ void unitarize_grad(const Vec &x, const std::vector<IS> &IS_interm_states, const
       while that for classic G-S requires only the norm of final v states.
      Their gradients, due to orthonormality, are equivalent to each other.
    */
-  Vec w = NULL;
+  Vec w;
   VecGetSubVector(x, IS_interm_states[0], &w);
   PetscInt dim2, dim;
   VecGetSize(w, &dim2);
@@ -930,6 +930,8 @@ void unitarize_grad(const Vec &x, const std::vector<IS> &IS_interm_states, const
         VecRestoreSubVector(w, IS_im, &wim);
         VecRestoreSubVector(vs[cinit], IS_re, &vsre);
         VecRestoreSubVector(vs[cinit], IS_im, &vsim);
+
+        VecRestoreSubVector(x, IS_interm_states[idxc], &w);
       }
 
       double vnorm = vnorms[iinit][iwindow];

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -707,7 +707,9 @@ void unitarize(const Vec &x, const std::vector<IS> &IS_interm_states, std::vecto
         VecGetArray(interm_ic[jinit][iwindow], &uptr);
         VecGetArray(interm_ic[iinit][iwindow], &vptr);
         for (int d = 0; d < dim; d++) {
+          // Re[v] -= Re[v.u] * Re[u] - Im[v.u] * Im[u]
           vptr[d] -= vu_re * uptr[d] - vu_im * uptr[d + dim];
+          // Im[v] -= Re[v.u] * Im[u] + Im[v.u] * Re[u]
           vptr[d + dim] -= vu_re * uptr[d + dim] + vu_im * uptr[d];
         }
         VecRestoreArray(interm_ic[jinit][iwindow], &uptr);


### PR DESCRIPTION
- The unitarity of intermediate conditions can be enforced by specifying the input `optim_unitarize_interm_ic=true`.
- This currently performs modified Gram-Schmidt operation on all processes, which needs parallelization in future.