### PR TITLE
Downsampling of (pt,qt) in simulate()

### DIFF
--- a/examples/pythoninterface/example_qft.py
+++ b/examples/pythoninterface/example_qft.py
@@ -48,7 +48,7 @@ print("Coupling: ", Jkl)
 
 # Set the pulse duration (ns)
 T = T_all[nqubits-1]
-dtau = 10.0  	# Bspline spacing [ns]
+spline_knot_spacing = 10.0 # Optional: Set Bspline spacing [ns]
 print("T=", T)
 
 # Set up rotational frame frequency
@@ -69,7 +69,7 @@ unitary = get_QFT_gate(np.prod(Ne))
 # print("Target gate: ", unitary)
 
 # Set up the Quandary configuration for this test case
-quandary = Quandary(Ne=Ne, Ng=Ng, freq01=freq01, Jkl=Jkl, rotfreq=rotfreq, T=T, targetgate=unitary, verbose=verbose, rand_seed=rand_seed, maxiter=maxiter, cw_amp_thres=cw_amp_thres, cw_prox_thres=cw_prox_thres, gamma_energy=gamma_energy) 
+quandary = Quandary(Ne=Ne, Ng=Ng, freq01=freq01, Jkl=Jkl, rotfreq=rotfreq, T=T, spline_knot_spacing=spline_knot_spacing, targetgate=unitary, verbose=verbose, rand_seed=rand_seed, maxiter=maxiter, cw_amp_thres=cw_amp_thres, cw_prox_thres=cw_prox_thres, gamma_energy=gamma_energy) 
 
 
 # Potentially, load initial control parameters from a file. 

--- a/examples/pythoninterface/optimize_then_perturb_controls.py
+++ b/examples/pythoninterface/optimize_then_perturb_controls.py
@@ -73,7 +73,7 @@ for iosc in range(Nsys):
 	p_seg = p_osc + 2.0*amp*(rng.random(Nelem)-0.5)
 	q_seg = q_osc + 2.0*amp*(rng.random(Nelem)-0.5)
 
-	pt_pert.append(p_seg) # for plot_pulse, is conversion to list needed?
+	pt_pert.append(p_seg)
 	qt_pert.append(q_seg)
 
 # plot the original perturbed pulse

--- a/examples/pythoninterface/optimize_then_perturb_controls.py
+++ b/examples/pythoninterface/optimize_then_perturb_controls.py
@@ -35,7 +35,7 @@ rand_seed=1234
 
 # For piecewise constant control functions, choose spline order of 0 (Default spline order would be 2, being 2nd order Bsplines). Note, the number spline basis functions for piecewise constant controls has to be much larger than if you use 2nd order Bsplines. Also note that if the spline order is zero, it is recommended not to use any carrier frequencies, which is already the default.
 spline_order = 0
-nsplines = 140
+spline_knot_spacing = 1.0  # [ns] Width of the constant control pieces
 
 # In order get less noisy control functions, activate the penalty term for variation of the control parameters
 gamma_variation = 1.0
@@ -44,7 +44,7 @@ gamma_variation = 1.0
 control_enforce_BC = True
 
 # Set up the Quandary configuration for this test case. Make sure to pass all of the above to the corresponding fields, compare help(Quandary)!
-quandary = Quandary(freq01=freq01, Jkl=Jkl, rotfreq=rotfreq, T=T, targetgate=unitary, verbose=verbose, rand_seed=rand_seed, spline_order=spline_order, nsplines=nsplines, gamma_variation=gamma_variation, control_enforce_BC=control_enforce_BC) 
+quandary = Quandary(freq01=freq01, Jkl=Jkl, rotfreq=rotfreq, T=T, targetgate=unitary, verbose=verbose, rand_seed=rand_seed, spline_order=spline_order, spline_knot_spacing=spline_knot_spacing, gamma_variation=gamma_variation, control_enforce_BC=control_enforce_BC) 
 
 # Optimize with quandary
 t, pt, qt, infidelity, expectedEnergy, population = quandary.optimize()

--- a/examples/pythoninterface/optimize_then_perturb_controls.py
+++ b/examples/pythoninterface/optimize_then_perturb_controls.py
@@ -4,8 +4,7 @@
 #   > export PATH=/path/to/quandary/:$PATH
 from quandary import * 
 
-## Two qubit test case, demonstrating the use of piecewise constant control functions with total variation penalty term. 
-# Also demonstrating how to perturb the control vector and evaluate the corresponding fidelity.
+## Two qubit test case, demonstrating the use of piecewise constant control functions with total variation penalty term. It also demonstrates how to perturb the control vector and evaluate the corresponding fidelity.
 # Here, the qubits have two levels each, no guard levels, with a dipole-dipole coupling 5MHz ##
 
 # 01 transition frequencies [GHz] per oscillator

--- a/quandary.py
+++ b/quandary.py
@@ -439,6 +439,8 @@ class Quandary:
             self.optim_hist = optim_hist
             self.time = time[:]
             self.uT   = uT.copy()
+            if len(pcof0) == 0:
+                self.pcof0 = popt[:]
         else:
             time = []
             pt = []
@@ -447,6 +449,9 @@ class Quandary:
             expectedEnergy = []
             population = []
         
+        if len(pcof0)>0:
+            self.pcof0 = pcof0[:]
+
         return time, pt, qt, infidelity, expectedEnergy, population
 
 

--- a/quandary.py
+++ b/quandary.py
@@ -326,7 +326,7 @@ class Quandary:
                     pcof0 = np.append(pcof0, seg_re) # append segment to the global control vector
                     pcof0 = np.append(pcof0, seg_im)
                 print("simulation(): downsampling of (pt0, qt0) completed")
-            else:
+            elif len(pt0) > 0 or len(qt0) > 0:
                 print("simulation(): the length of pt0 or qt0 != Nsys = ", Nsys)
         elif len(pt0) > 0 and len(qt0) > 0:
             print("Downsampling (pt,qt) is only implemented for spline order 0, not ", self.spline_order)

--- a/quandary.py
+++ b/quandary.py
@@ -170,6 +170,14 @@ class Quandary:
           - <nsteps>            : the number of time steps based on Hamiltonian eigenvalues and Pmin
           - <carrier_frequency> : carrier wave frequencies bases on system resonances
         """
+        
+        if self.spline_order == 0:
+            minspline = 1
+        elif self.spline_order == 2:
+            minspline = 5 if self.control_enforce_BC else 3
+        else:
+            print("Error: spline order = ", self.spline_order, " is currently not available. Choose 0 or 2.")
+            return -1
 
         # Set some defaults, if not set by the user
         if len(self.freq01) != len(self.Ne):
@@ -183,8 +191,10 @@ class Quandary:
         if len(self.gate_rot_freq) == 0:
             self.gate_rot_freq = np.zeros(len(self.rotfreq))
         if self.nsplines < 0:
-            minspline = 5 if self.control_enforce_BC else 3
+            #minspline = 5 if self.control_enforce_BC else 3
             self.nsplines = int(np.max([np.ceil(self.T/self.dtau + 2), minspline]))
+        else:
+            self.dtau = self.T/self.nsplines if self.spline_order == 0 else self.T/(self.nsplines - 2)
         if isinstance(self.initctrl_MHz, float) or isinstance(self.initctrl_MHz, int):
             max_alloscillators = self.initctrl_MHz
             self.initctrl_MHz = [max_alloscillators for _ in range(len(self.Ne))]
@@ -257,13 +267,15 @@ class Quandary:
         self.uT         = uT_org.copy()
 
 
-    def simulate(self, *, pcof0=[], maxcores=-1, datadir="./run_dir", quandary_exec="", cygwinbash="", batchargs=[]):
+    def simulate(self, *, pcof0=[], pt0=[], qt0=[], maxcores=-1, datadir="./run_dir", quandary_exec="", cygwinbash="", batchargs=[]):
         """ 
         Simulate the quantm dynamics using the current settings. 
 
         Optional arguments:
         ------------------- 
-        pcof0         : List of control parameters to be simulated. Default: Use use initial guess from the Quandary (pcof0, or pcof0_filename, or randomized initial guess)
+        pcof0         : List of control parameters to be simulated. Default: Use use initial guess from the quandary object (pcof0, or pcof0_filename, or randomized initial guess)
+        pt0           : List of ndarrays for the real part of the control function [MHz] for each oscillator, ndarray size = nsteps+1. Assumes spline_order == 0 and ignores the pcof0 argument. Default: []
+        qt0           : Same as pt0, but for the imaginary part.
         maxcores      : Maximum number of processing cores. Default: number of initial conditions
         datadir       : Data directory for storing output files. Default: "./run_dir"
         quandary_exec : Location of Quandary's C++ executable, if not in $PATH
@@ -273,11 +285,52 @@ class Quandary:
         Returns:
         --------
         time            :  List of time-points at which the controls are evaluated  (List)
-        pt, qt          :  p,q-control pulses at each time point for each oscillator (List of list)
+        pt, qt          :  p,q-control pulses [MHz] at each time point for each oscillator (List of list)
         infidelity      :  Infidelity of the pulses for the specified target operation (Float)
         expectedEnergy  :  Evolution of the expected energy of each oscillator and each initial condition. Acces: expectedEnergy[oscillator][initialcondition]
         population      :  Evolution of the population of each oscillator, of each initial condition. (expectedEnergy[oscillator][initialcondition])
         """
+        
+        if self.spline_order == 0: #specifying (pt, qt) only makes sense for piecewise constant B-splines
+            Nsys = len(self.Ne)
+            Nelem = self.nsteps+1
+            Nsplines = self.nsplines
+            if len(pt0) == Nsys and len(qt0) == Nsys:
+                sizes_ok = True
+                for iosc in range(Nsys):
+                    if sizes_ok and len(pt0[iosc]) == Nelem and len(qt0[iosc]) == Nelem:
+                        sizes_ok = True
+                    else:
+                        sizes_ok = False
+                # print("simulate(): sizes_ok = ", sizes_ok)
+                # do the downsampling and construct pcof0
+                pcof0 = np.zeros(0) # to hold the downsampled numpy array for the control vector
+                fact = 2e-3*np.pi # conversion factor from MHz to rad/ns
+                dt = self.T/self.nsteps # time step corresponding to (pt0, qt0)
+                for iosc in range(Nsys):
+                    p_seg = pt0[iosc]
+                    q_seg = qt0[iosc]
+
+                    seg_re = np.zeros(Nsplines) # to hold downsampled amplitudes
+                    seg_im = np.zeros(Nsplines)
+                    # downsample p_seg, q_seg
+                    for i_spl in range(Nsplines):
+                        # the B-spline0 coefficients correspond to the time levels
+                        # t_spl[i] = (ispl+0.5)*dtau, i_spl=0,1,...,self.nsplines-1
+                        t_spl = (i_spl+0.5)*self.dtau
+                        i = max(0, np.rint(t_spl/dt).astype(int))# given t_spl, find the closest time step index
+                        i = min(i, self.nsteps) # make sure i is in range
+                        seg_re[i_spl] = fact * p_seg[i]
+                        seg_im[i_spl] = fact * q_seg[i]
+
+                    pcof0 = np.append(pcof0, seg_re) # append segment to the global control vector
+                    pcof0 = np.append(pcof0, seg_im)
+                print("simulation(): downsampling of (pt0, qt0) completed")
+            else:
+                print("simulation(): the length of pt0 or qt0 != Nsys = ", Nsys)
+        elif len(pt0) > 0 and len(qt0) > 0:
+            print("Downsampling (pt,qt) is only implemented for spline order 0, not ", self.spline_order)
+        
 
         return self.__run(pcof0=pcof0, runtype="simulation", overwrite_popt=False, maxcores=maxcores, datadir=datadir, quandary_exec=quandary_exec, cygwinbash=cygwinbash, batchargs=batchargs)
 


### PR DESCRIPTION
The PR includes changes to all the (pt, qt) lists that are returned from optimize() to allow perturbations of each segment of the control to easily be modified. The modified controls (pt2, qt2) can now be given as arguments to simulate(), where they are first downsampled and then used to construct a global pcof array that is used in the simulation.