### PR TITLE
Fix compiler warnings

### DIFF
--- a/include/controlbasis.hpp
+++ b/include/controlbasis.hpp
@@ -33,11 +33,11 @@ class ControlBasis {
         virtual int getNSplines() {return 0;};
 
         /* Variation of control parameters */
-        virtual double computeVariation(std::vector<double>& params, int carrierfreqID){return 0.0;};
-        virtual void computeVariation_diff(double* grad, std::vector<double>&params, double var_bar, int carrierfreqID){};
+        virtual double computeVariation(std::vector<double>& /*params*/, int /*carrierfreqID*/){return 0.0;};
+        virtual void computeVariation_diff(double* /*grad*/, std::vector<double>& /*params*/, double /*var_bar*/, int /*carrierfreqID*/){};
 
         /* Default: do nothing. For some control parameterizations, this can be used to enforce that the controls start and end at zero. E.g. the Splines will overwrite the parameters x of the first and last two splines by zero, so that the splines start and end at zero. */
-        virtual void enforceBoundary(double* x, int carrier_id) {};
+        virtual void enforceBoundary(double* /*x*/, int /*carrier_id*/) {};
 
         /* Evaluate the Basis(alpha, t) at time t using the coefficients coeff. */
         virtual void evaluate(const double t, const std::vector<double>& coeff, int carrier_freq_id, double* Blt1, double*Blt2) = 0;
@@ -198,8 +198,8 @@ class ConstantTransferFunction : public TransferFunction {
         ConstantTransferFunction(double constant_, std::vector<double> onofftimes);
         ~ConstantTransferFunction();
 
-        double eval(double x, double time) {return isOn(constant, time); }; 
-        double der(double x, double time) {return 0.0; }; 
+        double eval(double /*x*/, double time) {return isOn(constant, time); }; 
+        double der(double /*x*/, double /*time*/) {return 0.0; }; 
 };
 
 /*
@@ -212,7 +212,7 @@ class IdentityTransferFunction : public TransferFunction {
         ~IdentityTransferFunction();
 
         double eval(double x, double time) {return isOn(x, time); };
-        double der(double x, double time) {return isOn(1.0, time); };
+        double der(double /*x*/, double time) {return isOn(1.0, time); };
 };
 
 

--- a/include/mastereq.hpp
+++ b/include/mastereq.hpp
@@ -437,7 +437,7 @@ inline void L1decay(const int it, const int n, const int i, const int ip, const 
 
 
 // Transpose of offdiagonal L1decay
-inline void L1decay_T(const int it, const int n, const int i, const int ip, const int stridei, const int strideip, const double* xptr, const double decayi, double* yre, double* yim){
+inline void L1decay_T(const int it, const int i, const int ip, const int stridei, const int strideip, const double* xptr, const double decayi, double* yre, double* yim){
   if (fabs(decayi) > 1e-12) {
       if (i > 0 && ip > 0) {
         double l1off = decayi * sqrt(i*ip);

--- a/include/mastereq.hpp
+++ b/include/mastereq.hpp
@@ -114,10 +114,10 @@ class MasterEq{
     void setTransferOnOffTimes(std::vector<double> tlist);
 
     /* Return the i-th oscillator */
-    Oscillator* getOscillator(const int i);
+    Oscillator* getOscillator(const size_t i);
 
     /* Return number of oscillators */
-    int getNOscillators();
+    size_t getNOscillators();
 
     /* Return dimension of vectorized system N^2 (for Lindblad solver) or N (for Schroedinger solver) */
     int getDim();

--- a/include/optimproblem.hpp
+++ b/include/optimproblem.hpp
@@ -20,7 +20,7 @@
 class OptimProblem {
 
   /* ODE stuff */
-  int ninit;                            /* Number of initial conditions to be considered (N^2, N, or 1) */
+  size_t ninit;                          /* Number of initial conditions to be considered (N^2, N, or 1) */
   int ninit_local;                      /* Local number of initial conditions on this processor */
   Vec rho_t0;                            /* Storage for initial condition of the ODE */
   Vec rho_t0_bar;                        /* Adjoint of ODE initial condition */

--- a/include/optimtarget.hpp
+++ b/include/optimtarget.hpp
@@ -21,7 +21,7 @@ class OptimTarget{
                                       If target is a gate, this holds the transformed state VrhoV^\dagger.
                                       If target is read from file, this holds the target density matrix from that file. */
     InitialConditionType initcond_type;    /* Type of initial conditions */
-    std::vector<int> initcond_IDs;         /* Integer list for pure-state initialization */
+    std::vector<size_t> initcond_IDs;      /* Integer list for pure-state initialization */
     LindbladType lindbladtype;             /* Type of decoherence (lindblad vs schroedinger) */
 
     Vec aux;      /* auxiliary vector needed when computing the objective for gate optimization */

--- a/include/oscillator.hpp
+++ b/include/oscillator.hpp
@@ -48,18 +48,18 @@ class Oscillator {
     int dim_postOsc;               // Dimension of coupled subsystem following this oscillator
 
     Oscillator();
-    Oscillator(MapParam config, int id, std::vector<int> nlevels_all_, std::vector<std::string>& controlsegments, std::vector<std::string>& controlinitializations, double ground_freq_, double selfkerr_, double rotational_freq_, double decay_time_, double dephase_time_, std::vector<double> carrier_freq_, double Tfinal_, LindbladType lindbladtype_, std::default_random_engine rand_engine);
+    Oscillator(MapParam config, size_t id, std::vector<int> nlevels_all_, std::vector<std::string>& controlsegments, std::vector<std::string>& controlinitializations, double ground_freq_, double selfkerr_, double rotational_freq_, double decay_time_, double dephase_time_, std::vector<double> carrier_freq_, double Tfinal_, LindbladType lindbladtype_, std::default_random_engine rand_engine);
     virtual ~Oscillator();
 
     /* Return the constants */
-    int getNParams() { return params.size(); };
-    int getNLevels() { return nlevels; };
+    size_t getNParams() { return params.size(); };
+    size_t getNLevels() { return nlevels; };
     double getSelfkerr() { return selfkerr; }; 
     double getDetuning() { return detuning_freq; }; 
     double getDecayTime() {return decay_time; };
     double getDephaseTime() {return dephase_time; };
-    int getNSegments() {return basisfunctions.size(); };
-    int getNCarrierfrequencies() {return carrier_freq.size(); };
+    size_t getNSegments() {return basisfunctions.size(); };
+    size_t getNCarrierfrequencies() {return carrier_freq.size(); };
     ControlType getControlType(int isegment=0) {return basisfunctions[isegment]->getType(); };
     int getNSplines(int isegment=0) {return basisfunctions[isegment]->getNSplines();};
     double getRotFreq() {return (ground_freq - detuning_freq) / (2.0*M_PI); };

--- a/include/timestepper.hpp
+++ b/include/timestepper.hpp
@@ -60,7 +60,7 @@ class TimeStepper{
     Vec solveODE(int initid, Vec rho_t0);
 
     /* Solve the adjoint ODE backwards in time from terminal condition rho_t0_bar */
-    void solveAdjointODE(int initid, Vec rho_t0_bar, Vec finalstate, double Jbar_penalty, double Jbar_penalty_dpdm, double Jbar_penalty_energy);
+    void solveAdjointODE(Vec rho_t0_bar, Vec finalstate, double Jbar_penalty, double Jbar_penalty_dpdm, double Jbar_penalty_energy);
 
     /* evaluate the penalty integral term */
     double penaltyIntegral(double time, const Vec x);

--- a/include/timestepper.hpp
+++ b/include/timestepper.hpp
@@ -50,7 +50,7 @@ class TimeStepper{
     bool storeFWD;       /* Flag that determines if primal states should be stored during forward evaluation */
 
     TimeStepper(); 
-    TimeStepper(MapParam config, MasterEq* mastereq_, int ntime_, double total_time_, Output* output_, bool storeFWD_); 
+    TimeStepper(MasterEq* mastereq_, int ntime_, double total_time_, Output* output_, bool storeFWD_); 
     virtual ~TimeStepper(); 
 
     /* Return the state at a certain time index */
@@ -84,7 +84,7 @@ class TimeStepper{
 class ExplEuler : public TimeStepper {
   Vec stage;
   public:
-    ExplEuler(MapParam config, MasterEq* mastereq_, int ntime_, double total_time_, Output* output_, bool storeFWD_);
+    ExplEuler(MasterEq* mastereq_, int ntime_, double total_time_, Output* output_, bool storeFWD_);
     ~ExplEuler();
 
     /* Evolve state forward from tstart to tstop */
@@ -116,7 +116,7 @@ class ImplMidpoint : public TimeStepper {
   Vec tmp, err;                    /* Auxiliary vector for applying the neuman iterations */
 
   public:
-    ImplMidpoint(MapParam config, MasterEq* mastereq_, int ntime_, double total_time_, LinearSolverType linsolve_type_, int linsolve_maxiter_, Output* output_, bool storeFWD_);
+    ImplMidpoint(MasterEq* mastereq_, int ntime_, double total_time_, LinearSolverType linsolve_type_, int linsolve_maxiter_, Output* output_, bool storeFWD_);
     ~ImplMidpoint();
 
 
@@ -140,7 +140,7 @@ class CompositionalImplMidpoint : public ImplMidpoint {
   int order;
 
   public:
-    CompositionalImplMidpoint(MapParam config, int order_, MasterEq* mastereq_, int ntime_, double total_time_, LinearSolverType linsolve_type_, int linsolve_maxiter_, Output* output_, bool storeFWD_);
+    CompositionalImplMidpoint(int order_, MasterEq* mastereq_, int ntime_, double total_time_, LinearSolverType linsolve_type_, int linsolve_maxiter_, Output* output_, bool storeFWD_);
     ~CompositionalImplMidpoint();
 
     void evolveFWD(const double tstart, const double tstop, Vec x);

--- a/include/timestepper.hpp
+++ b/include/timestepper.hpp
@@ -54,7 +54,7 @@ class TimeStepper{
     virtual ~TimeStepper(); 
 
     /* Return the state at a certain time index */
-    Vec getState(int tindex);
+    Vec getState(size_t tindex);
 
     /* Solve the ODE forward in time with initial condition rho_t0. Return state at final time step */
     Vec solveODE(int initid, Vec rho_t0);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,10 +50,6 @@ if(WITH_SLEPC)
     target_compile_options(quandary PRIVATE -DWITH_SLEPC)
 endif()
 
-# Suppress compiler warnings temporarily
-# TODO fix these and remove this!
-add_definitions(-w)
-
 install(
     TARGETS quandary
     RUNTIME DESTINATION bin

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -184,7 +184,6 @@ void MapParam::GetVecIntParam(std::string key, std::vector<int> &fillme, int def
 {
   std::map<std::string, std::string>::const_iterator it_value = this->find(key);
   std::string lineexp;
-  double val;
   if (it_value == this->end())
   {
     if (mpi_rank == 0 && !quietmode && warnme)

--- a/src/controlbasis.cpp
+++ b/src/controlbasis.cpp
@@ -65,7 +65,7 @@ void BSpline2nd::evaluate(const double t, const std::vector<double>& coeff, int 
 
 }
 
-void BSpline2nd::derivative(const double t, const std::vector<double>& coeff, double* coeff_diff, const double valbar1, const double valbar2, int carrier_freq_id) {
+void BSpline2nd::derivative(const double t, const std::vector<double>& /*coeff*/, double* coeff_diff, const double valbar1, const double valbar2, int carrier_freq_id) {
 
     /* Iterate over basis function */
     for (int l=0; l<nsplines; l++) {
@@ -242,7 +242,7 @@ void BSpline0::evaluate(const double t, const std::vector<double>& coeff, int ca
     }
 }
 
-void BSpline0::derivative(const double t, const std::vector<double>& coeff, double* coeff_diff, const double valbar1, const double valbar2, int carrier_freq_id) {
+void BSpline0::derivative(const double t, const std::vector<double>& /*coeff*/, double* coeff_diff, const double valbar1, const double valbar2, int carrier_freq_id) {
 
     // Figure out which basis function is active at this time point 
     int splineID = ceil((t-tstart)/dtknot - 0.5);

--- a/src/controlbasis.cpp
+++ b/src/controlbasis.cpp
@@ -332,7 +332,7 @@ void TransferFunction::storeOnOffTimes(std::vector<double>onofftimes_){
 
     // Copy the list of time points that determine when the transfer functions are active
     onofftimes.clear();
-    for (int i=0; i<onofftimes_.size(); i++) {
+    for (size_t i=0; i<onofftimes_.size(); i++) {
         onofftimes.push_back( onofftimes_[i] );
     }   
 }

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -17,19 +17,19 @@ Gate::Gate(std::vector<int> nlevels_, std::vector<int> nessential_, double time_
   final_time = time_;
   gate_rot_freq = gate_rot_freq_;
   lindbladtype = lindbladtype_;
-  for (int i=0; i<gate_rot_freq.size(); i++){
+  for (size_t i=0; i<gate_rot_freq.size(); i++){
     gate_rot_freq[i] *= 2.*M_PI;
   }
 
   /* Dimension of gate = \prod_j nessential_j */
   dim_ess = 1;
-  for (int i=0; i<nessential.size(); i++) {
+  for (size_t i=0; i<nessential.size(); i++) {
     dim_ess *= nessential[i];
   }
 
   /* Dimension of system matrix rho */
   dim_rho = 1;
-  for (int i=0; i<nlevels.size(); i++) {
+  for (size_t i=0; i<nlevels.size(); i++) {
     dim_rho *= nlevels[i];
   }
 
@@ -98,10 +98,10 @@ void Gate::assembleGate(){
   for (PetscInt row=0; row<dim_ess; row++){
     int r = row;
     double freq = 0.0;
-    for (int iosc=0; iosc<nlevels.size(); iosc++){
+    for (size_t iosc=0; iosc<nlevels.size(); iosc++){
       // compute dimension of essential levels of all following subsystems 
       int dim_post = 1;
-      for (int josc=iosc+1; josc<nlevels.size();josc++) {
+      for (size_t josc=iosc+1; josc<nlevels.size();josc++) {
         dim_post *= nessential[josc];
       }
       // compute the frequency 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -363,7 +363,6 @@ int main(int argc,char **argv)
 
   /* My time stepper */
   bool storeFWD = false;
-  int ninit_local = ninit / mpisize_init; 
   if (mastereq->lindbladtype != LindbladType::NONE &&   
      (runtype == RunType::GRADIENT || runtype == RunType::OPTIMIZATION) ) storeFWD = true;  // if NOT Schroedinger solver and running gradient optim: store forward states. Otherwise, they will be recomputed during gradient. 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -369,10 +369,10 @@ int main(int argc,char **argv)
 
   std::string timesteppertypestr = config.GetStrParam("timestepper", "IMR");
   TimeStepper* mytimestepper;
-  if (timesteppertypestr.compare("IMR")==0) mytimestepper = new ImplMidpoint(config, mastereq, ntime, total_time, linsolvetype, linsolve_maxiter, output, storeFWD);
-  else if (timesteppertypestr.compare("IMR4")==0) mytimestepper = new CompositionalImplMidpoint(config, 4, mastereq, ntime, total_time, linsolvetype, linsolve_maxiter, output, storeFWD);
-  else if (timesteppertypestr.compare("IMR8")==0) mytimestepper = new CompositionalImplMidpoint(config, 8, mastereq, ntime, total_time, linsolvetype, linsolve_maxiter, output, storeFWD);
-  else if (timesteppertypestr.compare("EE")==0) mytimestepper = new ExplEuler(config, mastereq, ntime, total_time, output, storeFWD);
+  if (timesteppertypestr.compare("IMR")==0) mytimestepper = new ImplMidpoint(mastereq, ntime, total_time, linsolvetype, linsolve_maxiter, output, storeFWD);
+  else if (timesteppertypestr.compare("IMR4")==0) mytimestepper = new CompositionalImplMidpoint(4, mastereq, ntime, total_time, linsolvetype, linsolve_maxiter, output, storeFWD);
+  else if (timesteppertypestr.compare("IMR8")==0) mytimestepper = new CompositionalImplMidpoint(8, mastereq, ntime, total_time, linsolvetype, linsolve_maxiter, output, storeFWD);
+  else if (timesteppertypestr.compare("EE")==0) mytimestepper = new ExplEuler(mastereq, ntime, total_time, output, storeFWD);
   else {
     printf("\n\n ERROR: Unknow timestepping type: %s.\n\n", timesteppertypestr.c_str());
     exit(1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,12 +87,12 @@ int main(int argc,char **argv)
   /* Get the number of essential levels per oscillator. 
    * Default: same as number of levels */  
   std::vector<int> nessential(nlevels.size());
-  for (int iosc = 0; iosc<nlevels.size(); iosc++) nessential[iosc] = nlevels[iosc];
+  for (size_t iosc = 0; iosc<nlevels.size(); iosc++) nessential[iosc] = nlevels[iosc];
   /* Overwrite if config option is given */
   std::vector<int> read_nessential;
   config.GetVecIntParam("nessential", read_nessential, -1);
   if (read_nessential[0] > -1) {
-    for (int iosc = 0; iosc<nlevels.size(); iosc++){
+    for (size_t iosc = 0; iosc<nlevels.size(); iosc++){
       if (iosc < read_nessential.size()) nessential[iosc] = read_nessential[iosc];
       else                               nessential[iosc] = read_nessential[read_nessential.size()-1];
       if (nessential[iosc] > nlevels[iosc]) nessential[iosc] = nlevels[iosc];
@@ -113,7 +113,7 @@ int main(int argc,char **argv)
   else if (initcondstr[0].compare("Nplus1") == 0 )  {
     // compute system dimension N 
     ninit = 1;
-    for (int i=0; i<nlevels.size(); i++){
+    for (size_t i=0; i<nlevels.size(); i++){
       ninit *= nlevels[i];
     }
     ninit +=1;
@@ -123,10 +123,10 @@ int main(int argc,char **argv)
     /* Compute ninit = dim(subsystem defined by list of oscil IDs) */
     ninit = 1;
     if (initcondstr.size() < 2) {
-      for (int j=0; j<nlevels.size(); j++)  initcondstr.push_back(std::to_string(j));
+      for (size_t j=0; j<nlevels.size(); j++)  initcondstr.push_back(std::to_string(j));
     }
-    for (int i = 1; i<initcondstr.size(); i++){
-      int oscilID = atoi(initcondstr[i].c_str());
+    for (size_t i = 1; i<initcondstr.size(); i++){
+      size_t oscilID = atoi(initcondstr[i].c_str());
       if (oscilID < nessential.size()) ninit *= nessential[oscilID];
     }
     if (initcondstr[0].compare("basis") == 0  ) {
@@ -235,7 +235,7 @@ int main(int argc,char **argv)
   // Get control segment types, carrierwaves and control initialization
   std::string default_seg_str = "spline, 10, 0.0, "+std::to_string(total_time); // Default for first oscillator control segment
   std::string default_init_str = "constant, 0.0";                               // Default for first oscillator initialization
-  for (int i = 0; i < nlevels.size(); i++){
+  for (size_t i = 0; i < nlevels.size(); i++){
     // Get carrier wave frequencies 
     std::vector<double> carrier_freq;
     std::string key = "carrier_frequency" + std::to_string(i);
@@ -255,8 +255,8 @@ int main(int argc,char **argv)
     // Update the default for control type
     default_seg_str = "";
     default_init_str = "";
-    for (int l = 0; l<controltype_str.size(); l++) default_seg_str += controltype_str[l]+=", ";
-    for (int l = 0; l<controlinit_str.size(); l++) default_init_str += controlinit_str[l]+=", ";
+    for (size_t l = 0; l<controltype_str.size(); l++) default_seg_str += controltype_str[l]+=", ";
+    for (size_t l = 0; l<controlinit_str.size(); l++) default_init_str += controlinit_str[l]+=", ";
   }
 
   // Get pi-pulses, if any
@@ -269,16 +269,16 @@ int main(int argc,char **argv)
       printf("apply_pipulse config option: <oscilID>, <tstart>, <tstop>, <amp>, <anotherOscilID>, <anotherTstart>, <anotherTstop>, <anotherAmp> ...\n");
       exit(1);
     }
-    int k=0;
+    size_t k=0;
     while (k < pipulse_str.size()){
       // Set pipulse for this oscillator
-      int pipulse_id = atoi(pipulse_str[k+0].c_str());
+      size_t pipulse_id = atoi(pipulse_str[k+0].c_str());
       oscil_vec[pipulse_id]->pipulse.tstart.push_back(atof(pipulse_str[k+1].c_str()));
       oscil_vec[pipulse_id]->pipulse.tstop.push_back(atof(pipulse_str[k+2].c_str()));
       oscil_vec[pipulse_id]->pipulse.amp.push_back(atof(pipulse_str[k+3].c_str()));
-      if (mpirank_world==0) printf("Applying PiPulse to oscillator %d in [%f,%f]: |p+iq|=%f\n", pipulse_id, oscil_vec[pipulse_id]->pipulse.tstart.back(), oscil_vec[pipulse_id]->pipulse.tstop.back(), oscil_vec[pipulse_id]->pipulse.amp.back());
+      if (mpirank_world==0) printf("Applying PiPulse to oscillator %zu in [%f,%f]: |p+iq|=%f\n", pipulse_id, oscil_vec[pipulse_id]->pipulse.tstart.back(), oscil_vec[pipulse_id]->pipulse.tstop.back(), oscil_vec[pipulse_id]->pipulse.amp.back());
       // Set zero control for all other oscillators during this pipulse
-      for (int i=0; i<nlevels.size(); i++){
+      for (size_t i=0; i<nlevels.size(); i++){
         if (i != pipulse_id) {
           oscil_vec[i]->pipulse.tstart.push_back(atof(pipulse_str[k+1].c_str()));
           oscil_vec[i]->pipulse.tstop.push_back(atof(pipulse_str[k+2].c_str()));
@@ -312,8 +312,8 @@ int main(int argc,char **argv)
   // Compute coupling rotation frequencies eta_ij = w^r_i - w^r_j
   std::vector<double> eta(nlevels.size()*(nlevels.size()-1)/2.);
   int idx = 0;
-  for (int iosc=0; iosc<nlevels.size(); iosc++){
-    for (int josc=iosc+1; josc<nlevels.size(); josc++){
+  for (size_t iosc=0; iosc<nlevels.size(); iosc++){
+    for (size_t josc=iosc+1; josc<nlevels.size(); josc++){
       eta[idx] = rot_freq[iosc] - rot_freq[josc];
       idx++;
     }
@@ -334,12 +334,12 @@ int main(int argc,char **argv)
   // Some screen output 
   if (mpirank_world == 0 && !quietmode) {
     std::cout<< "System: ";
-    for (int i=0; i<nlevels.size(); i++) {
+    for (size_t i=0; i<nlevels.size(); i++) {
       std::cout<< nlevels[i];
       if (i < nlevels.size()-1) std::cout<< "x";
     }
     std::cout<<"  (essential levels: ";
-    for (int i=0; i<nlevels.size(); i++) {
+    for (size_t i=0; i<nlevels.size(); i++) {
       std::cout<< nessential[i];
       if (i < nlevels.size()-1) std::cout<< "x";
     }
@@ -729,7 +729,7 @@ int main(int argc,char **argv)
 #endif
 
   /* Clean up */
-  for (int i=0; i<nlevels.size(); i++){
+  for (size_t i=0; i<nlevels.size(); i++){
     delete oscil_vec[i];
   }
   delete [] oscil_vec;

--- a/src/mastereq.cpp
+++ b/src/mastereq.cpp
@@ -14,8 +14,6 @@ MasterEq::MasterEq(){
 
 
 MasterEq::MasterEq(std::vector<int> nlevels_, std::vector<int> nessential_, Oscillator** oscil_vec_, const std::vector<double> crosskerr_, const std::vector<double> Jkl_, const std::vector<double> eta_, LindbladType lindbladtype_, bool usematfree_, std::string hamiltonian_file_, bool quietmode_) {
-  int ierr;
-
   nlevels = nlevels_;
   nessential = nessential_;
   noscillators = nlevels.size();
@@ -365,7 +363,6 @@ void MasterEq::initSparseMatSolver(){
 
       /* Get dimensions */
       int nk     = oscil_vec[iosc]->getNLevels();
-      int nprek  = oscil_vec[iosc]->dim_preOsc;
       int npostk = oscil_vec[iosc]->dim_postOsc;
 
       /* Set control Hamiltonian system matrix real(-iHc) */
@@ -462,7 +459,6 @@ void MasterEq::initSparseMatSolver(){
         if (fabs(Jkl[id_kl]) > 1e-12) { // only allocate if coefficient is non-zero to save memory.
           // Dimensions of joscillator
           int nj     = oscil_vec[josc]->getNLevels();
-          int nprej  = oscil_vec[josc]->dim_preOsc;
           int npostj = oscil_vec[josc]->dim_postOsc;
 
           /* Iterate over local rows of Ad_vec / Bd_vec */
@@ -519,7 +515,6 @@ void MasterEq::initSparseMatSolver(){
     for (int iosc = 0; iosc < noscillators; iosc++) {
 
       int nk     = oscil_vec[iosc]->getNLevels();
-      int nprek  = oscil_vec[iosc]->dim_preOsc;
       int npostk = oscil_vec[iosc]->dim_postOsc;
       double xik = oscil_vec[iosc]->getSelfkerr();
       double detunek = oscil_vec[iosc]->getDetuning();
@@ -590,7 +585,6 @@ void MasterEq::initSparseMatSolver(){
 
         // Dimensions 
         int nk     = oscil_vec[iosc]->getNLevels();
-        int nprek  = oscil_vec[iosc]->dim_preOsc;
         int npostk = oscil_vec[iosc]->dim_postOsc;
 
         /* Iterate over local rows of Ad */
@@ -726,7 +720,6 @@ int MasterEq::getNOscillators() { return noscillators; }
 Oscillator* MasterEq::getOscillator(const int i) { return oscil_vec[i]; }
 
 int MasterEq::assemble_RHS(const double t){
-  int ierr;
   /* Prepare the matrix shell to perform the action of RHS on a vector */
 
   // Set the time

--- a/src/mastereq.cpp
+++ b/src/mastereq.cpp
@@ -1680,7 +1680,7 @@ int myMatMultTranspose_matfree(Mat RHS, Vec x, Vec y){
           /* --- Offdiagonal part of decay L1^T */
           if (shellctx->lindbladtype != LindbladType::NONE) {
             // Oscillators 0
-            L1decay_T(it, n0, i0, i0p, stridei0, stridei0p, xptr, decay0, &yre, &yim);
+            L1decay_T(it, i0, i0p, stridei0, stridei0p, xptr, decay0, &yre, &yim);
           }
 
           /* --- Control hamiltonian  --- */
@@ -1923,9 +1923,9 @@ int myMatMultTranspose_matfree(Mat RHS, Vec x, Vec y){
           /* --- Offdiagonal part of decay L1^T */
           if (shellctx->lindbladtype != LindbladType::NONE) {
             // Oscillators 0
-            L1decay_T(it, n0, i0, i0p, stridei0, stridei0p, xptr, decay0, &yre, &yim);
+            L1decay_T(it, i0, i0p, stridei0, stridei0p, xptr, decay0, &yre, &yim);
             // Oscillator 1
-            L1decay_T(it, n1, i1, i1p, stridei1, stridei1p, xptr, decay1, &yre, &yim);
+            L1decay_T(it, i1, i1p, stridei1, stridei1p, xptr, decay1, &yre, &yim);
           }
 
           /* --- Control hamiltonian  --- */
@@ -2225,11 +2225,11 @@ int myMatMultTranspose_matfree(Mat RHS, Vec x, Vec y){
               /* --- Offdiagonal part of decay L1^T */
               if (shellctx->lindbladtype != LindbladType::NONE) {
                 // Oscillators 0
-                L1decay_T(it, n0, i0, i0p, stridei0, stridei0p, xptr, decay0, &yre, &yim);
+                L1decay_T(it, i0, i0p, stridei0, stridei0p, xptr, decay0, &yre, &yim);
                 // Oscillator 1
-                L1decay_T(it, n1, i1, i1p, stridei1, stridei1p, xptr, decay1, &yre, &yim);
+                L1decay_T(it, i1, i1p, stridei1, stridei1p, xptr, decay1, &yre, &yim);
                 // Oscillator 2
-                L1decay_T(it, n2, i2, i2p, stridei2, stridei2p, xptr, decay2, &yre, &yim);
+                L1decay_T(it, i2, i2p, stridei2, stridei2p, xptr, decay2, &yre, &yim);
               }
 
               /* --- Control hamiltonian  --- */
@@ -2610,13 +2610,13 @@ int myMatMultTranspose_matfree(Mat RHS, Vec x, Vec y){
                   /* --- Offdiagonal part of decay L1^T */
                   if (shellctx->lindbladtype != LindbladType::NONE) {
                     // Oscillators 0
-                    L1decay_T(it, n0, i0, i0p, stridei0, stridei0p, xptr, decay0, &yre, &yim);
+                    L1decay_T(it, i0, i0p, stridei0, stridei0p, xptr, decay0, &yre, &yim);
                     // Oscillator 1
-                    L1decay_T(it, n1, i1, i1p, stridei1, stridei1p, xptr, decay1, &yre, &yim);
+                    L1decay_T(it, i1, i1p, stridei1, stridei1p, xptr, decay1, &yre, &yim);
                     // Oscillator 2
-                    L1decay_T(it, n2, i2, i2p, stridei2, stridei2p, xptr, decay2, &yre, &yim);
+                    L1decay_T(it, i2, i2p, stridei2, stridei2p, xptr, decay2, &yre, &yim);
                     // Oscillator 3
-                    L1decay_T(it, n3, i3, i3p, stridei3, stridei3p, xptr, decay3, &yre, &yim);
+                    L1decay_T(it, i3, i3p, stridei3, stridei3p, xptr, decay3, &yre, &yim);
                   }
 
                   /* --- Control hamiltonian  --- */
@@ -3089,15 +3089,15 @@ int myMatMultTranspose_matfree(Mat RHS, Vec x, Vec y){
                       /* --- Offdiagonal part of decay L1^T */
                       if (shellctx->lindbladtype != LindbladType::NONE) { 
                         // Oscillators 0
-                        L1decay_T(it, n0, i0, i0p, stridei0, stridei0p, xptr, decay0, &yre, &yim);
+                        L1decay_T(it, i0, i0p, stridei0, stridei0p, xptr, decay0, &yre, &yim);
                         // Oscillator 1
-                        L1decay_T(it, n1, i1, i1p, stridei1, stridei1p, xptr, decay1, &yre, &yim);
+                        L1decay_T(it, i1, i1p, stridei1, stridei1p, xptr, decay1, &yre, &yim);
                         // Oscillator 2
-                        L1decay_T(it, n2, i2, i2p, stridei2, stridei2p, xptr, decay2, &yre, &yim);
+                        L1decay_T(it, i2, i2p, stridei2, stridei2p, xptr, decay2, &yre, &yim);
                         // Oscillator 3
-                        L1decay_T(it, n3, i3, i3p, stridei3, stridei3p, xptr, decay3, &yre, &yim);
+                        L1decay_T(it, i3, i3p, stridei3, stridei3p, xptr, decay3, &yre, &yim);
                         // Oscillator 4
-                        L1decay_T(it, n4, i4, i4p, stridei4, stridei4p, xptr, decay4, &yre, &yim);
+                        L1decay_T(it, i4, i4p, stridei4, stridei4p, xptr, decay4, &yre, &yim);
                       }
 
                       /* --- Control hamiltonian  --- */

--- a/src/mastereq.cpp
+++ b/src/mastereq.cpp
@@ -284,7 +284,7 @@ void MasterEq::initSparseMatSolver(){
   // One control operator per oscillator
   // Ac_vec[0] = real(-i Hc) and Bc_vec[0] = imag(-i Hc)
   for (int iosc = 0; iosc < noscillators; iosc++) {
-    Mat myAcMatk, myBcMatk;
+    Mat myAcMatk = nullptr, myBcMatk = nullptr;
     std::vector<Mat> myAcvec_k{myAcMatk};   
     std::vector<Mat> myBcvec_k{myBcMatk};
     Ac_vec.push_back(myAcvec_k);
@@ -312,7 +312,7 @@ void MasterEq::initSparseMatSolver(){
   for (int iosc = 0; iosc < noscillators; iosc++) {
     for (int josc=iosc+1; josc<noscillators; josc++){
       if (fabs(Jkl[id_kl]) > 1e-12) { // only allocate if Jkl>0
-        Mat myAdkl, myBdkl;
+        Mat myAdkl = nullptr, myBdkl = nullptr;
         Ad_vec.push_back(myAdkl);
         Bd_vec.push_back(myBdkl);
         MatCreate(PETSC_COMM_WORLD, &Ad_vec[id_kl]);

--- a/src/mastereq.cpp
+++ b/src/mastereq.cpp
@@ -27,13 +27,13 @@ MasterEq::MasterEq(std::vector<int> nlevels_, std::vector<int> nessential_, Osci
   quietmode = quietmode_;
 
 
-  for (int i=0; i<crosskerr.size(); i++){
+  for (size_t i=0; i<crosskerr.size(); i++){
     crosskerr[i] *= 2.*M_PI;
   }
-  for (int i=0; i<Jkl.size(); i++){
+  for (size_t i=0; i<Jkl.size(); i++){
     Jkl[i] *= 2.*M_PI;
   }
-  for (int i=0; i<eta.size(); i++){
+  for (size_t i=0; i<eta.size(); i++){
     eta[i] *= 2.*M_PI;
   }
 
@@ -135,7 +135,7 @@ MasterEq::MasterEq(std::vector<int> nlevels_, std::vector<int> nessential_, Osci
 
   /* Compute maximum number of design parameters over all oscillators */
   nparams_max = 0;
-  for (int ioscil = 0; ioscil < getNOscillators(); ioscil++) {
+  for (size_t ioscil = 0; ioscil < getNOscillators(); ioscil++) {
       int n = getOscillator(ioscil)->getNParams();
       if (n > nparams_max) nparams_max = n;
   }
@@ -169,18 +169,18 @@ MasterEq::MasterEq(std::vector<int> nlevels_, std::vector<int> nessential_, Osci
   RHSctx.time = 0.0;
   for (int iosc = 0; iosc < noscillators; iosc++) {
     std::vector<double> controlRek;
-    for (int icon=0; icon<transfer_Hc_re[iosc].size(); icon++){ 
+    for (size_t icon=0; icon<transfer_Hc_re[iosc].size(); icon++){ 
      controlRek.push_back(0.0);
     }
     RHSctx.control_Re.push_back(controlRek);
     std::vector<double> controlImk;
-    for (int icon=0; icon<transfer_Hc_im[iosc].size(); icon++){ 
+    for (size_t icon=0; icon<transfer_Hc_im[iosc].size(); icon++){ 
      controlImk.push_back(0.0);
     }
     RHSctx.control_Im.push_back(controlImk);
   }
-  for (int kl = 0; kl<transfer_Hdt_re.size(); kl++) RHSctx.eval_transfer_Hdt_re.push_back(0.0);
-  for (int kl = 0; kl<transfer_Hdt_im.size(); kl++) RHSctx.eval_transfer_Hdt_im.push_back(0.0);
+  for (size_t kl = 0; kl<transfer_Hdt_re.size(); kl++) RHSctx.eval_transfer_Hdt_re.push_back(0.0);
+  for (size_t kl = 0; kl<transfer_Hdt_im.size(); kl++) RHSctx.eval_transfer_Hdt_im.push_back(0.0);
 
   /* Set the MatMult routine for applying the RHS to a vector x */
   if (usematfree) { // matrix-free solver
@@ -217,39 +217,39 @@ MasterEq::~MasterEq(){
     if (!usematfree){
       MatDestroy(&Ad);
       MatDestroy(&Bd);
-      for (int k=0; k<Ad_vec.size(); k++) {
+      for (size_t k=0; k<Ad_vec.size(); k++) {
         if (Ad_vec[k] != NULL) {
           MatDestroy(&(Ad_vec[k]));
         }
       }
-      for (int k=0; k<Bd_vec.size(); k++) {
+      for (size_t k=0; k<Bd_vec.size(); k++) {
         if (Bd_vec[k] != NULL) {
           MatDestroy(&(Bd_vec[k]));
         }
       }
       VecDestroy(&aux);
-      for (int i=0; i<Ac_vec.size(); i++){
-        for (int icon=0; icon<Ac_vec[i].size(); icon++)  {
+      for (size_t i=0; i<Ac_vec.size(); i++){
+        for (size_t icon=0; icon<Ac_vec[i].size(); icon++)  {
           if (Ac_vec[i][icon] != NULL) {
             MatDestroy(&(Ac_vec[i][icon]));
           }
         }
       }
-      for (int i=0; i<Bc_vec.size(); i++){
-        for (int icon=0; icon<Bc_vec[i].size(); icon++)  {
+      for (size_t i=0; i<Bc_vec.size(); i++){
+        for (size_t icon=0; icon<Bc_vec[i].size(); icon++)  {
           if (Bc_vec[i][icon] != NULL) {
             MatDestroy(&(Bc_vec[i][icon]));
           }
         }
       }
     }
-    for (int i=0; i<transfer_Hdt_re.size(); i++) delete transfer_Hdt_re[i];
-    for (int i=0; i<transfer_Hdt_im.size(); i++) delete transfer_Hdt_im[i];
-    for (int i=0; i<transfer_Hc_re.size(); i++) {
-      for (int icon=0; icon<transfer_Hc_re[i].size(); icon++) delete transfer_Hc_re[i][icon];
+    for (size_t i=0; i<transfer_Hdt_re.size(); i++) delete transfer_Hdt_re[i];
+    for (size_t i=0; i<transfer_Hdt_im.size(); i++) delete transfer_Hdt_im[i];
+    for (size_t i=0; i<transfer_Hc_re.size(); i++) {
+      for (size_t icon=0; icon<transfer_Hc_re[i].size(); icon++) delete transfer_Hc_re[i][icon];
     }
-    for (int i=0; i<transfer_Hc_im.size(); i++) {
-      for (int icon=0; icon<transfer_Hc_im[i].size(); icon++) delete transfer_Hc_im[i][icon];
+    for (size_t i=0; i<transfer_Hc_im.size(); i++) {
+      for (size_t icon=0; icon<transfer_Hc_im[i].size(); icon++) delete transfer_Hc_im[i][icon];
     }
     delete [] dRedp;
     delete [] dImdp;
@@ -662,7 +662,7 @@ void MasterEq::initSparseMatSolver(){
   }
 
   // Remove control parameters for those oscillators that are non-controllable
-  for (int k=0; k<nlevels.size(); k++){
+  for (size_t k=0; k<nlevels.size(); k++){
     PetscScalar norm;
     MatNorm(Ac_vec[k][0], NORM_FROBENIUS, &norm);
     if (norm < 1e-14) {
@@ -715,9 +715,9 @@ int MasterEq::getDimEss(){ return dim_ess; }
 
 int MasterEq::getDimRho(){ return dim_rho; }
 
-int MasterEq::getNOscillators() { return noscillators; }
+size_t MasterEq::getNOscillators() { return noscillators; }
 
-Oscillator* MasterEq::getOscillator(const int i) { return oscil_vec[i]; }
+Oscillator* MasterEq::getOscillator(const size_t i) { return oscil_vec[i]; }
 
 int MasterEq::assemble_RHS(const double t){
   /* Prepare the matrix shell to perform the action of RHS on a vector */
@@ -732,22 +732,22 @@ int MasterEq::assemble_RHS(const double t){
     oscil_vec[iosc]->evalControl(t, &p, &q);  // Evaluates the B-spline basis functions -> p(t,alpha), q(t,alpha)
 
     // Iterate over control terms for this oscillator
-    for (int icon=0; icon<transfer_Hc_re[iosc].size(); icon++){
+    for (size_t icon=0; icon<transfer_Hc_re[iosc].size(); icon++){
       // Get transfer functions u^k_i(p) (Default: Identity. But could be different if python interface)
       double ukip = transfer_Hc_re[iosc][icon]->eval(p, t);
       RHSctx.control_Re[iosc][icon] = ukip; 
     } 
-    for (int icon=0; icon<transfer_Hc_im[iosc].size(); icon++){
+    for (size_t icon=0; icon<transfer_Hc_im[iosc].size(); icon++){
       double ukiq = transfer_Hc_im[iosc][icon]->eval(q, t);
       RHSctx.control_Im[iosc][icon] = ukiq;
     } 
   } 
 
   // Evaluate and store transfer for time-dependent system term
-  for (int kl=0; kl<transfer_Hdt_re.size(); kl++)
+  for (size_t kl=0; kl<transfer_Hdt_re.size(); kl++)
     // REAL part: Default trans_re = Jkl*cos(etakl*t) , or from python interface
     RHSctx.eval_transfer_Hdt_re[kl] = transfer_Hdt_re[kl]->eval(t, t); 
-  for (int kl=0; kl<transfer_Hdt_im.size(); kl++)
+  for (size_t kl=0; kl<transfer_Hdt_im.size(); kl++)
     // IMAG part: Default trans_im = Jkl*sin(etakl*t)
     RHSctx.eval_transfer_Hdt_im[kl] = transfer_Hdt_im[kl]->eval(t, t); 
 
@@ -1247,11 +1247,11 @@ void MasterEq::computedRHSdp(const double t, const Vec x, const Vec xbar, const 
     std::vector<double> dukidq;
     double p, q;
     oscil_vec[iosc]->evalControl(t, &p, &q);  // Evaluates the B-spline basis functions -> p(t,alpha), q(t,alpha)
-    for (int icon=0; icon<Bc_vec[iosc].size(); icon++){ // Now evaluate the derivative of transfer functions for each control term
+    for (size_t icon=0; icon<Bc_vec[iosc].size(); icon++){ // Now evaluate the derivative of transfer functions for each control term
       double dukidp_tmp = transfer_Hc_re[iosc][icon]->der(p, t); // dudp(p)
       dukidp.push_back(dukidp_tmp);
     }
-    for (int icon=0; icon<Ac_vec[iosc].size(); icon++){ 
+    for (size_t icon=0; icon<Ac_vec[iosc].size(); icon++){ 
       double dukidq_tmp = transfer_Hc_im[iosc][icon]->der(q, t); // dvdq(q)
       dukidq.push_back(dukidq_tmp);
     }
@@ -1261,12 +1261,12 @@ void MasterEq::computedRHSdp(const double t, const Vec x, const Vec xbar, const 
     double vAvbar = 0.0;
     double vBubar = 0.0;
     double uBvbar = 0.0;
-    for (int icon=0; icon<Ac_vec[iosc].size(); icon++){
+    for (size_t icon=0; icon<Ac_vec[iosc].size(); icon++){
       double dot;
       MatMult(Ac_vec[iosc][icon], u, aux); VecDot(aux, ubar, &dot); uAubar += dot * dukidq[icon];
       MatMult(Ac_vec[iosc][icon], v, aux); VecDot(aux, vbar, &dot); vAvbar += dot * dukidq[icon];
     }
-    for (int icon=0; icon<Bc_vec[iosc].size(); icon++){
+    for (size_t icon=0; icon<Bc_vec[iosc].size(); icon++){
       double dot;
       MatMult(Bc_vec[iosc][icon], u, aux); VecDot(aux, vbar, &dot); uBvbar += dot * dukidp[icon];
       MatMult(Bc_vec[iosc][icon], v, aux); VecDot(aux, ubar, &dot); vBubar += dot * dukidp[icon];
@@ -1303,7 +1303,7 @@ void MasterEq::setControlAmplitudes(const Vec x) {
   /* Pass design vector x to oscillators */
   // Design storage: x = (params_oscil0, params_oscil2, ... ) 
   int shift=0;
-  for (int ioscil = 0; ioscil < getNOscillators(); ioscil++) {
+  for (size_t ioscil = 0; ioscil < getNOscillators(); ioscil++) {
     /* Copy x into the oscillators parameter array. */
     getOscillator(ioscil)->setParams(ptr + shift);
     shift += getOscillator(ioscil)->getNParams();
@@ -1347,10 +1347,10 @@ int myMatMult_sparsemat(Mat RHS, Vec x, Vec y){
 
 
   /* -- Control Terms -- */
-  for (int iosc = 0; iosc < shellctx->nlevels.size(); iosc++) {
+  for (size_t iosc = 0; iosc < shellctx->nlevels.size(); iosc++) {
 
     // Iterate over control terms for this oscillator
-    for (int icon=0; icon<shellctx->Ac_vec[iosc].size(); icon++){
+    for (size_t icon=0; icon<shellctx->Ac_vec[iosc].size(); icon++){
       q = shellctx->control_Im[iosc][icon];
       // uout += q^k*Acu
       MatMult(shellctx->Ac_vec[iosc][icon], u, *shellctx->aux);
@@ -1359,7 +1359,7 @@ int myMatMult_sparsemat(Mat RHS, Vec x, Vec y){
       MatMult(shellctx->Ac_vec[iosc][icon], v, *shellctx->aux);
       VecAXPY(vout, q, *shellctx->aux);
     }
-    for (int icon=0; icon<shellctx->Bc_vec[iosc].size(); icon++){
+    for (size_t icon=0; icon<shellctx->Bc_vec[iosc].size(); icon++){
       p = shellctx->control_Re[iosc][icon];
       // uout -= p^kBcv
       MatMult(shellctx->Bc_vec[iosc][icon], v, *shellctx->aux);
@@ -1373,7 +1373,7 @@ int myMatMult_sparsemat(Mat RHS, Vec x, Vec y){
   /* --- Apply time-dependent system Hamiltonian --- */
   /* By default (no python interface), these are the Jayes-Cumming coupling terms */
   // REAL
-  for (int id_kl = 0; id_kl<shellctx->Bd_vec.size(); id_kl++){
+  for (size_t id_kl = 0; id_kl<shellctx->Bd_vec.size(); id_kl++){
     double trans_re = shellctx->eval_transfer_Hdt_re[id_kl]; // Default: trans_re = Jkl*cos(etakl*t) 
 
     // printf("%f %f %f\n", shellctx->time, trans_re, trans_im);
@@ -1392,7 +1392,7 @@ int myMatMult_sparsemat(Mat RHS, Vec x, Vec y){
     }
   }
   // IMAG
-  for (int id_kl = 0; id_kl<shellctx->Ad_vec.size(); id_kl++){
+  for (size_t id_kl = 0; id_kl<shellctx->Ad_vec.size(); id_kl++){
     // Get transfer function
     double trans_im = shellctx->eval_transfer_Hdt_im[id_kl]; // Default: trans_im = Jkl*sin(etakl*t)
 
@@ -1455,10 +1455,10 @@ int myMatMultTranspose_sparsemat(Mat RHS, Vec x, Vec y) {
   MatMultTransposeAdd(*shellctx->Ad, v, vout, vout);
 
   /* Time-dependent control term */
-  for (int iosc = 0; iosc < shellctx->nlevels.size(); iosc++) {
+  for (size_t iosc = 0; iosc < shellctx->nlevels.size(); iosc++) {
 
     // Iterate over control terms for this oscillator
-    for (int icon=0; icon<shellctx->Ac_vec[iosc].size(); icon++){
+    for (size_t icon=0; icon<shellctx->Ac_vec[iosc].size(); icon++){
       q = shellctx->control_Im[iosc][icon];
       // uout += q^k*Ac^Tu
       MatMultTranspose(shellctx->Ac_vec[iosc][icon], u, *shellctx->aux);
@@ -1467,7 +1467,7 @@ int myMatMultTranspose_sparsemat(Mat RHS, Vec x, Vec y) {
       MatMultTranspose(shellctx->Ac_vec[iosc][icon], v, *shellctx->aux);
       VecAXPY(vout, q, *shellctx->aux);
     }
-    for (int icon=0; icon<shellctx->Bc_vec[iosc].size(); icon++){
+    for (size_t icon=0; icon<shellctx->Bc_vec[iosc].size(); icon++){
       p = shellctx->control_Re[iosc][icon];
       // uout += p^kBc^Tv
       MatMultTranspose(shellctx->Bc_vec[iosc][icon], v, *shellctx->aux);
@@ -1482,7 +1482,7 @@ int myMatMultTranspose_sparsemat(Mat RHS, Vec x, Vec y) {
   /* --- Apply time-dependent system Hamiltonian --- */
   /* By default (no python interface), these are the Jayes-Cumming coupling terms */
   // REAL
-  for (int id_kl = 0; id_kl<shellctx->Bd_vec.size(); id_kl++){
+  for (size_t id_kl = 0; id_kl<shellctx->Bd_vec.size(); id_kl++){
     double trans_re = shellctx->eval_transfer_Hdt_re[id_kl]; // Default: trans_re = Jkl*cos(etakl*t) 
     if (fabs(trans_re) > 1e-12) {
       // uout += +Jkl*cos*Bdklv^T
@@ -1494,7 +1494,7 @@ int myMatMultTranspose_sparsemat(Mat RHS, Vec x, Vec y) {
     }
   }
   // IMAG
-  for (int id_kl = 0; id_kl<shellctx->Ad_vec.size(); id_kl++){
+  for (size_t id_kl = 0; id_kl<shellctx->Ad_vec.size(); id_kl++){
     // Get transfer function
     double trans_im = shellctx->eval_transfer_Hdt_im[id_kl]; // Default: trans_im = Jkl*sin(etakl*t)
 
@@ -3186,7 +3186,7 @@ void MasterEq::population(const Vec x, std::vector<double> &pop){
   for (int k=0; k<dim_rho; k++){
     pop.push_back(0.0);
   }
-  assert (pop.size() == dim_rho);
+  assert (pop.size() == static_cast<size_t>(dim_rho));
 
   std::vector<double> mypop(dim_rho, 0.0);
 
@@ -3217,7 +3217,7 @@ void MasterEq::population(const Vec x, std::vector<double> &pop){
   } 
 
   /* Gather poppulation from all Petsc processors */
-  for (int i=0; i<mypop.size(); i++) {pop[i] = mypop[i];}
+  for (size_t i=0; i<mypop.size(); i++) {pop[i] = mypop[i];}
   MPI_Allreduce(mypop.data(), pop.data(), dim_rho, MPI_DOUBLE, MPI_SUM, PETSC_COMM_WORLD);
 }
 

--- a/src/optimproblem.cpp
+++ b/src/optimproblem.cpp
@@ -167,7 +167,7 @@ OptimProblem::OptimProblem(MapParam config, TimeStepper* timestepper_, MPI_Comm 
   TaoSetType(tao,TAOBQNLS);         // Optim type: taoblmvm vs BQNLS ??
   TaoSetMaximumIterations(tao, maxiter);
   TaoSetTolerances(tao, gatol, PETSC_DEFAULT, grtol);
-  TaoSetMonitor(tao, TaoMonitor, (void*)this, NULL);
+  TaoMonitorSet(tao, TaoMonitor, (void*)this, NULL);
   TaoSetVariableBounds(tao, xlower, xupper);
   TaoSetFromOptions(tao);
   /* Set user-defined objective and gradient evaluation routines */

--- a/src/optimproblem.cpp
+++ b/src/optimproblem.cpp
@@ -486,7 +486,7 @@ void OptimProblem::evalGradF(const Vec x, Vec G){
       int iinit_global = mpirank_init * ninit_local + iinit;
 
       /* Recompute the initial state and target */
-      int initid = optim_target->prepareInitialState(iinit_global, ninit, timestepper->mastereq->nlevels, timestepper->mastereq->nessential, rho_t0);
+      optim_target->prepareInitialState(iinit_global, ninit, timestepper->mastereq->nlevels, timestepper->mastereq->nessential, rho_t0);
       optim_target->prepareTargetState(rho_t0);
      
       /* Reset adjoint */

--- a/src/optimproblem.cpp
+++ b/src/optimproblem.cpp
@@ -423,7 +423,7 @@ void OptimProblem::evalGradF(const Vec x, Vec G){
       optim_target->evalJ_diff(finalstate, rho_t0_bar, obj_weights[iinit]*obj_cost_re_bar, obj_weights[iinit]*obj_cost_im_bar);
 
       /* Derivative of time-stepping */
-      timestepper->solveAdjointODE(initid, rho_t0_bar, finalstate, obj_weights[iinit] * gamma_penalty, obj_weights[iinit]*gamma_penalty_dpdm, obj_weights[iinit]*gamma_penalty_energy);
+      timestepper->solveAdjointODE(rho_t0_bar, finalstate, obj_weights[iinit] * gamma_penalty, obj_weights[iinit]*gamma_penalty_dpdm, obj_weights[iinit]*gamma_penalty_energy);
 
       /* Add to optimizers's gradient */
       VecAXPY(G, 1.0, timestepper->redgrad);
@@ -498,7 +498,7 @@ void OptimProblem::evalGradF(const Vec x, Vec G){
       optim_target->evalJ_diff(store_finalstates[iinit], rho_t0_bar, obj_weights[iinit]*obj_cost_re_bar, obj_weights[iinit]*obj_cost_im_bar);
 
       /* Derivative of time-stepping */
-      timestepper->solveAdjointODE(initid, rho_t0_bar, store_finalstates[iinit], obj_weights[iinit] * gamma_penalty, obj_weights[iinit]*gamma_penalty_dpdm, obj_weights[iinit]*gamma_penalty_energy);
+      timestepper->solveAdjointODE(rho_t0_bar, store_finalstates[iinit], obj_weights[iinit] * gamma_penalty, obj_weights[iinit]*gamma_penalty_dpdm, obj_weights[iinit]*gamma_penalty_energy);
 
       /* Add to optimizers's gradient */
       VecAXPY(G, 1.0, timestepper->redgrad);

--- a/src/optimproblem.cpp
+++ b/src/optimproblem.cpp
@@ -37,7 +37,7 @@ OptimProblem::OptimProblem(MapParam config, TimeStepper* timestepper_, MPI_Comm 
 
   /* Store number of design parameters */
   int n = 0;
-  for (int ioscil = 0; ioscil < timestepper->mastereq->getNOscillators(); ioscil++) {
+  for (size_t ioscil = 0; ioscil < timestepper->mastereq->getNOscillators(); ioscil++) {
       n += timestepper->mastereq->getOscillator(ioscil)->getNParams(); 
   }
   ndesign = n;
@@ -75,17 +75,17 @@ OptimProblem::OptimProblem(MapParam config, TimeStepper* timestepper_, MPI_Comm 
   assert(obj_weights.size() >= ninit);
   // Scale the weights such that they sum up to one: beta_i <- beta_i / (\sum_i beta_i)
   double scaleweights = 0.0;
-  for (int i=0; i<ninit; i++) scaleweights += obj_weights[i];
-  for (int i=0; i<ninit; i++) obj_weights[i] = obj_weights[i] / scaleweights;
+  for (size_t i=0; i<ninit; i++) scaleweights += obj_weights[i];
+  for (size_t i=0; i<ninit; i++) obj_weights[i] = obj_weights[i] / scaleweights;
   // Distribute over mpi_init processes 
   double sendbuf[obj_weights.size()];
   double recvbuf[obj_weights.size()];
-  for (int i = 0; i < obj_weights.size(); i++) sendbuf[i] = obj_weights[i];
-  for (int i = 0; i < obj_weights.size(); i++) recvbuf[i] = obj_weights[i];
+  for (size_t i = 0; i < obj_weights.size(); i++) sendbuf[i] = obj_weights[i];
+  for (size_t i = 0; i < obj_weights.size(); i++) recvbuf[i] = obj_weights[i];
   int nscatter = ninit_local;
   MPI_Scatter(sendbuf, nscatter, MPI_DOUBLE, recvbuf, nscatter,  MPI_DOUBLE, 0, comm_init);
   for (int i = 0; i < nscatter; i++) obj_weights[i] = recvbuf[i];
-  for (int i=nscatter; i < obj_weights.size(); i++) obj_weights[i] = 0.0;
+  for (size_t i=nscatter; i < obj_weights.size(); i++) obj_weights[i] = 0.0;
 
 
   /* Store other optimization parameters */
@@ -122,10 +122,10 @@ OptimProblem::OptimProblem(MapParam config, TimeStepper* timestepper_, MPI_Comm 
   VecSetFromOptions(xlower);
   VecDuplicate(xlower, &xupper);
   int col = 0;
-  for (int iosc = 0; iosc < timestepper->mastereq->getNOscillators(); iosc++){
+  for (size_t iosc = 0; iosc < timestepper->mastereq->getNOscillators(); iosc++){
     std::vector<std::string> bound_str;
     config.GetVecStrParam("control_bounds" + std::to_string(iosc), bound_str, "10000.0");
-    for (int iseg = 0; iseg < timestepper->mastereq->getOscillator(iosc)->getNSegments(); iseg++){
+    for (size_t iseg = 0; iseg < timestepper->mastereq->getOscillator(iosc)->getNSegments(); iseg++){
       double boundval = 0.0;
       if (bound_str.size() <= iseg) boundval =  atof(bound_str[bound_str.size()-1].c_str());
       else boundval = atof(bound_str[iseg].c_str());
@@ -138,7 +138,7 @@ OptimProblem::OptimProblem(MapParam config, TimeStepper* timestepper_, MPI_Comm 
       }
       // Disable bound for phase if this is spline_amplitude control
       if (timestepper->mastereq->getOscillator(iosc)->getControlType() == ControlType::BSPLINEAMP) {
-        for (int f = 0; f < timestepper->mastereq->getOscillator(iosc)->getNCarrierfrequencies(); f++){
+        for (size_t f = 0; f < timestepper->mastereq->getOscillator(iosc)->getNCarrierfrequencies(); f++){
           int nsplines = timestepper->mastereq->getOscillator(iosc)->getNSplines();
           boundval = 1e+10;
           VecSetValue(xupper, col + f*(nsplines+1) + nsplines, boundval, INSERT_VALUES);
@@ -199,7 +199,7 @@ OptimProblem::~OptimProblem() {
   VecDestroy(&xinit);
   VecDestroy(&xtmp);
 
-  for (int i = 0; i < store_finalstates.size(); i++) {
+  for (size_t i = 0; i < store_finalstates.size(); i++) {
     VecDestroy(&(store_finalstates[i]));
   }
 
@@ -307,7 +307,7 @@ double OptimProblem::evalF(const Vec x) {
 
   /* Evaluate penality term for control variation */
   double var_reg = 0.0;
-  for (int iosc = 0; iosc < timestepper->mastereq->getNOscillators(); iosc++){
+  for (size_t iosc = 0; iosc < timestepper->mastereq->getNOscillators(); iosc++){
     var_reg += timestepper->mastereq->getOscillator(iosc)->evalControlVariation(); // uses Oscillator::params instead of 'x'
   }
   obj_penal_variation = 0.5*gamma_penalty_variation*var_reg; 
@@ -351,7 +351,7 @@ void OptimProblem::evalGradF(const Vec x, Vec G){
     // Derivative of penalization of control variation 
     double var_reg_bar = 0.5*gamma_penalty_variation;
     int skip_to_oscillator = 0;
-    for (int iosc = 0; iosc < timestepper->mastereq->getNOscillators(); iosc++){
+    for (size_t iosc = 0; iosc < timestepper->mastereq->getNOscillators(); iosc++){
       Oscillator* osc = timestepper->mastereq->getOscillator(iosc);
       osc->evalControlVariationDiff(G, var_reg_bar, skip_to_oscillator);
       skip_to_oscillator += osc->getNParams();
@@ -470,7 +470,7 @@ void OptimProblem::evalGradF(const Vec x, Vec G){
 
   /* Evaluate penalty term for control parameter variation */
   double var_reg = 0.0;
-  for (int iosc = 0; iosc < timestepper->mastereq->getNOscillators(); iosc++){
+  for (size_t iosc = 0; iosc < timestepper->mastereq->getNOscillators(); iosc++){
     var_reg += timestepper->mastereq->getOscillator(iosc)->evalControlVariation(); // uses Oscillator::params instead of 'x'
   }
   obj_penal_variation = 0.5*gamma_penalty_variation*var_reg; 
@@ -534,7 +534,7 @@ void OptimProblem::getStartingPoint(Vec xinit){
 
   if (initguess_fromfile.size() > 0) {
     /* Set the initial guess from file */
-    for (int i=0; i<initguess_fromfile.size(); i++) {
+    for (size_t i=0; i<initguess_fromfile.size(); i++) {
       VecSetValue(xinit, i, initguess_fromfile[i], INSERT_VALUES);
     }
 
@@ -542,7 +542,7 @@ void OptimProblem::getStartingPoint(Vec xinit){
     PetscScalar* xptr;
     VecGetArray(xinit, &xptr);
     int shift = 0;
-    for (int ioscil = 0; ioscil<mastereq->getNOscillators(); ioscil++){
+    for (size_t ioscil = 0; ioscil<mastereq->getNOscillators(); ioscil++){
       mastereq->getOscillator(ioscil)->getParams(xptr + shift);
       shift += mastereq->getOscillator(ioscil)->getNParams();
     }

--- a/src/optimproblem.cpp
+++ b/src/optimproblem.cpp
@@ -656,7 +656,7 @@ PetscErrorCode TaoEvalObjectiveAndGradient(Tao tao, Vec x, PetscReal *f, Vec G, 
   return 0;
 }
 
-PetscErrorCode TaoEvalObjective(Tao tao, Vec x, PetscReal *f, void*ptr){
+PetscErrorCode TaoEvalObjective(Tao /*tao*/, Vec x, PetscReal *f, void*ptr){
 
   OptimProblem* ctx = (OptimProblem*) ptr;
   *f = ctx->evalF(x);
@@ -665,7 +665,7 @@ PetscErrorCode TaoEvalObjective(Tao tao, Vec x, PetscReal *f, void*ptr){
 }
 
 
-PetscErrorCode TaoEvalGradient(Tao tao, Vec x, Vec G, void*ptr){
+PetscErrorCode TaoEvalGradient(Tao /*tao*/, Vec x, Vec G, void*ptr){
 
   OptimProblem* ctx = (OptimProblem*) ptr;
   ctx->evalGradF(x, G);

--- a/src/optimtarget.cpp
+++ b/src/optimtarget.cpp
@@ -57,9 +57,9 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, std::string object
   }
   /* Get list of involved oscillators */
   if (initcond_str.size() < 2) 
-    for (int j=0; j<mastereq->getNOscillators(); j++)   
+    for (size_t j=0; j<mastereq->getNOscillators(); j++)   
       initcond_str.push_back(std::to_string(j)); // Default: all oscillators
-  for (int i=1; i<initcond_str.size(); i++) 
+  for (size_t i=1; i<initcond_str.size(); i++) 
     initcond_IDs.push_back(atoi(initcond_str[i].c_str())); // Overwrite with config option, if given.
 
   /* Prepare initial state rho_t0 if PURE or FROMFILE or ENSEMBLE initialization. Otherwise they are set within prepareInitialState during evalF. */
@@ -68,18 +68,18 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, std::string object
   if (initcond_type == InitialConditionType::PURE) { 
     /* Initialize with tensor product of unit vectors. */
     if (initcond_IDs.size() != mastereq->getNOscillators()) {
-      printf("ERROR during pure-state initialization: List of IDs must contain %d elements!\n", mastereq->getNOscillators());
+      printf("ERROR during pure-state initialization: List of IDs must contain %zu elements!\n", mastereq->getNOscillators());
       exit(1);
     }
     int diag_id = 0;
-    for (int k=0; k < initcond_IDs.size(); k++) {
+    for (size_t k=0; k < initcond_IDs.size(); k++) {
       if (initcond_IDs[k] > mastereq->getOscillator(k)->getNLevels()-1){
-        printf("ERROR in config setting. The requested pure state initialization |%d> exceeds the number of allowed levels for that oscillator (%d).\n", initcond_IDs[k], mastereq->getOscillator(k)->getNLevels());
+        printf("ERROR in config setting. The requested pure state initialization |%zu> exceeds the number of allowed levels for that oscillator (%zu).\n", initcond_IDs[k], mastereq->getOscillator(k)->getNLevels());
         exit(1);
       }
       assert (initcond_IDs[k] < mastereq->getOscillator(k)->getNLevels());
       int dim_postkron = 1;
-      for (int m=k+1; m < initcond_IDs.size(); m++) {
+      for (size_t m=k+1; m < initcond_IDs.size(); m++) {
         dim_postkron *= mastereq->getOscillator(m)->getNLevels();
       }
       diag_id += initcond_IDs[k] * dim_postkron;
@@ -131,7 +131,7 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, std::string object
     // Sanity check for the list in initcond_IDs!
     assert(initcond_IDs.size() >= 1); // at least one element 
     assert(initcond_IDs[initcond_IDs.size()-1] < mastereq->getNOscillators()); // last element can't exceed total number of oscillators
-    for (int i=0; i < initcond_IDs.size()-1; i++){ // list should be consecutive!
+    for (size_t i=0; i < initcond_IDs.size()-1; i++){ // list should be consecutive!
       if (initcond_IDs[i]+1 != initcond_IDs[i+1]) {
         printf("ERROR: List of oscillators for ensemble initialization should be consecutive!\n");
         exit(1);
@@ -140,7 +140,7 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, std::string object
     // get dimension of subsystems defined by initcond_IDs, as well as the one before and after. Span in essential levels only.
     int dimpost = 1;
     int dimsub = 1;
-    for (int i=0; i<mastereq->getNOscillators(); i++){
+    for (size_t i=0; i<mastereq->getNOscillators(); i++){
       if (initcond_IDs[0] <= i && i <= initcond_IDs[initcond_IDs.size()-1]) dimsub *= mastereq->nessential[i];
       else dimpost *= mastereq->nessential[i];
     }
@@ -204,10 +204,10 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, std::string object
       if (target_str.size() - 1 < mastereq->getNOscillators()) {
         copyLast(target_str, mastereq->getNOscillators()+1);
       }
-      for (int i=0; i < mastereq->getNOscillators(); i++) {
-        int Qi_state = atoi(target_str[i+1].c_str());
+      for (size_t i=0; i < mastereq->getNOscillators(); i++) {
+        size_t Qi_state = atoi(target_str[i+1].c_str());
         if (Qi_state >= mastereq->getOscillator(i)->getNLevels()) {
-          printf("ERROR in config setting. The requested pure state target |%d> exceeds the number of modeled levels for that oscillator (%d).\n", Qi_state, mastereq->getOscillator(i)->getNLevels());
+          printf("ERROR in config setting. The requested pure state target |%zu> exceeds the number of modeled levels for that oscillator (%zu).\n", Qi_state, mastereq->getOscillator(i)->getNLevels());
           exit(1);
         }
         purestateID += Qi_state * mastereq->getOscillator(i)->dim_postOsc;
@@ -538,7 +538,7 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, std::vect
 
       /* Get dimension of partial system behind last oscillator ID (essential levels only) */
       dim_post = 1;
-      for (int k = initcond_IDs[initcond_IDs.size()-1] + 1; k < nessential.size(); k++) {
+      for (size_t k = initcond_IDs[initcond_IDs.size()-1] + 1; k < nessential.size(); k++) {
         // dim_post *= getOscillator(k)->getNLevels();
         dim_post *= nessential[k];
       }
@@ -572,7 +572,7 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, std::vect
 
       /* Get dimension of partial system behind last oscillator ID (essential levels only) */
       dim_post = 1;
-      for (int k = initcond_IDs[initcond_IDs.size()-1] + 1; k < nessential.size(); k++) {
+      for (size_t k = initcond_IDs[initcond_IDs.size()-1] + 1; k < nessential.size(); k++) {
         dim_post *= nessential[k];
       }
 

--- a/src/optimtarget.cpp
+++ b/src/optimtarget.cpp
@@ -138,12 +138,10 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, std::string object
       }
     }
     // get dimension of subsystems defined by initcond_IDs, as well as the one before and after. Span in essential levels only.
-    int dimpre = 1;
     int dimpost = 1;
     int dimsub = 1;
     for (int i=0; i<mastereq->getNOscillators(); i++){
-      if (i < initcond_IDs[0]) dimpre *= mastereq->nessential[i];
-      else if (initcond_IDs[0] <= i && i <= initcond_IDs[initcond_IDs.size()-1]) dimsub *= mastereq->nessential[i];
+      if (initcond_IDs[0] <= i && i <= initcond_IDs[initcond_IDs.size()-1]) dimsub *= mastereq->nessential[i];
       else dimpost *= mastereq->nessential[i];
     }
     int dimrho = mastereq->getDimRho();
@@ -535,7 +533,7 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, std::vect
       break;
 
     case InitialConditionType::DIAGONAL:
-      int row, diagelem;
+      int diagelem;
       VecZeroEntries(rho0);
 
       /* Get dimension of partial system behind last oscillator ID (essential levels only) */
@@ -665,7 +663,7 @@ void OptimTarget::evalJ(const Vec state, double* J_re_ptr, double* J_im_ptr){
   double J_re = 0.0;
   double J_im = 0.0;
   PetscInt diagID, diagID_re, diagID_im;
-  double sum, mine, rhoii, rhoii_re, rhoii_im, lambdai, norm;
+  double sum, rhoii, rhoii_re, rhoii_im, lambdai, norm;
   PetscInt ilo, ihi;
   int dimsq;
 
@@ -744,7 +742,7 @@ void OptimTarget::evalJ(const Vec state, double* J_re_ptr, double* J_im_ptr){
 
 void OptimTarget::evalJ_diff(const Vec state, Vec statebar, const double J_re_bar, const double J_im_bar){
   PetscInt ilo, ihi;
-  double lambdai, val, val_re, val_im, rhoii_re, rhoii_im;
+  double lambdai, val, rhoii_re, rhoii_im;
   PetscInt diagID, diagID_re, diagID_im, dimsq;
 
   switch (objective_type) {

--- a/src/oscillator.cpp
+++ b/src/oscillator.cpp
@@ -7,7 +7,7 @@ Oscillator::Oscillator(){
   control_enforceBC = true;
 }
 
-Oscillator::Oscillator(MapParam config, int id, std::vector<int> nlevels_all_, std::vector<std::string>& controlsegments, std::vector<std::string>& controlinitializations, double ground_freq_, double selfkerr_, double rotational_freq_, double decay_time_, double dephase_time_, std::vector<double> carrier_freq_, double Tfinal_, LindbladType lindbladtype_, std::default_random_engine rand_engine){
+Oscillator::Oscillator(MapParam config, size_t id, std::vector<int> nlevels_all_, std::vector<std::string>& controlsegments, std::vector<std::string>& controlinitializations, double ground_freq_, double selfkerr_, double rotational_freq_, double decay_time_, double dephase_time_, std::vector<double> carrier_freq_, double Tfinal_, LindbladType lindbladtype_, std::default_random_engine rand_engine){
 
   myid = id;
   nlevels = nlevels_all_[id];
@@ -16,7 +16,7 @@ Oscillator::Oscillator(MapParam config, int id, std::vector<int> nlevels_all_, s
   selfkerr = selfkerr_*2.0*M_PI;
   detuning_freq = 2.0*M_PI*(ground_freq_ - rotational_freq_);
   carrier_freq = carrier_freq_;
-  for (int i=0; i<carrier_freq.size(); i++) {
+  for (size_t i=0; i<carrier_freq.size(); i++) {
     carrier_freq[i] *= 2.0*M_PI;
   }
   decay_time = decay_time_;
@@ -30,7 +30,7 @@ Oscillator::Oscillator(MapParam config, int id, std::vector<int> nlevels_all_, s
   control_enforceBC = config.GetBoolParam("control_enforceBC", true);
 
   // Parse for control segments
-  int idstr = 0;
+  size_t idstr = 0;
   int nparams_per_seg = 0;
   while (idstr < controlsegments.size()) {
 
@@ -119,8 +119,8 @@ Oscillator::Oscillator(MapParam config, int id, std::vector<int> nlevels_all_, s
   }
 
   //Initialization of the control parameters for each segment
-  int idini = 0;
-  for (int seg = 0; seg < basisfunctions.size(); seg++) {
+  size_t idini = 0;
+  for (size_t seg = 0; seg < basisfunctions.size(); seg++) {
     // Set a default if initialization string is not given for this segment
     if (controlinitializations.size() < idini+2) {
       controlinitializations.push_back("constant");
@@ -137,7 +137,7 @@ Oscillator::Oscillator(MapParam config, int id, std::vector<int> nlevels_all_, s
         initval = std::max(0.0, initval);  
         initval = std::min(1.0, initval); 
       }
-      for (int f = 0; f<carrier_freq.size(); f++) {
+      for (size_t f = 0; f<carrier_freq.size(); f++) {
         for (int i=0; i<basisfunctions[seg]->getNparams(); i++){
           params.push_back(initval);
         }
@@ -152,7 +152,7 @@ Oscillator::Oscillator(MapParam config, int id, std::vector<int> nlevels_all_, s
       // Uniform distribution [0,1)
       std::uniform_real_distribution<double> unit_dist(0.0, 1.0);
 
-      for (int f = 0; f<carrier_freq.size(); f++) {
+      for (size_t f = 0; f<carrier_freq.size(); f++) {
         for (int i=0; i<basisfunctions[seg]->getNparams(); i++){
           double randval = unit_dist(rand_engine);  // random in [0,1]
           // scale to chosen amplitude 
@@ -174,7 +174,7 @@ Oscillator::Oscillator(MapParam config, int id, std::vector<int> nlevels_all_, s
         }
       }
     } else {
-      for (int i=0; i<basisfunctions[seg]->getNparams() * carrier_freq.size(); i++){
+      for (size_t i=0; i<basisfunctions[seg]->getNparams() * carrier_freq.size(); i++){
         params.push_back(0.0);
       }
     }
@@ -183,8 +183,8 @@ Oscillator::Oscillator(MapParam config, int id, std::vector<int> nlevels_all_, s
 
   /* Make sure the initial guess satisfies the boundary conditions, if needed */
   if (params.size() > 0 && control_enforceBC){
-    for (int bs = 0; bs < basisfunctions.size(); bs++){
-      for (int f=0; f < carrier_freq.size(); f++) {
+    for (size_t bs = 0; bs < basisfunctions.size(); bs++){
+      for (size_t f=0; f < carrier_freq.size(); f++) {
         basisfunctions[bs]->enforceBoundary(params.data(), f);
       }
     }
@@ -193,7 +193,7 @@ Oscillator::Oscillator(MapParam config, int id, std::vector<int> nlevels_all_, s
   /* Compute and store dimension of preceding and following oscillators */
   dim_preOsc = 1;
   dim_postOsc = 1;
-  for (int j=0; j<nlevels_all_.size(); j++) {
+  for (size_t j=0; j<nlevels_all_.size(); j++) {
     if (j < id) dim_preOsc  *= nlevels_all_[j];
     if (j > id) dim_postOsc *= nlevels_all_[j];
   }
@@ -202,7 +202,7 @@ Oscillator::Oscillator(MapParam config, int id, std::vector<int> nlevels_all_, s
 
 Oscillator::~Oscillator(){
   if (params.size() > 0) {
-    for (int i=0; i<basisfunctions.size(); i++) 
+    for (size_t i=0; i<basisfunctions.size(); i++) 
       delete basisfunctions[i];
   }
 }
@@ -210,13 +210,13 @@ Oscillator::~Oscillator(){
 void Oscillator::setParams(const double* x){
 
   // copy x into the oscillators parameter storage
-  for (int i=0; i<params.size(); i++) {
+  for (size_t i=0; i<params.size(); i++) {
     params[i] = x[i]; 
   }
 }
 
 void Oscillator::getParams(double* x){
-  for (int i=0; i<params.size(); i++) {
+  for (size_t i=0; i<params.size(); i++) {
     x[i] = params[i]; 
   }
 }
@@ -224,7 +224,7 @@ void Oscillator::getParams(double* x){
 int Oscillator::getNSegParams(int segmentID){
   int n = 0;
   if (params.size()>0) {
-    assert(basisfunctions.size() > segmentID);
+    assert(basisfunctions.size() > static_cast<size_t>(segmentID));
     n = basisfunctions[segmentID]->getNparams()*carrier_freq.size();
   }
   return n; 
@@ -235,9 +235,9 @@ double Oscillator::evalControlVariation(){
   double var_reg = 0.0;
   if (params.size()>0) {
     // Iterate over control segments
-    for (int iseg= 0; iseg< basisfunctions.size(); iseg++){
+    for (size_t iseg= 0; iseg< basisfunctions.size(); iseg++){
       /* Iterate over carrier frequencies */
-      for (int f=0; f < carrier_freq.size(); f++) {
+      for (size_t f=0; f < carrier_freq.size(); f++) {
         var_reg += basisfunctions[iseg]->computeVariation(params, f);
       }
     }
@@ -253,9 +253,9 @@ void Oscillator::evalControlVariationDiff(Vec G, double var_reg_bar, int skip_to
     VecGetArray(G, &grad);
 
     // Iterate over basis parameterizations??? 
-    for (int iseg = 0; iseg< basisfunctions.size(); iseg++){
+    for (size_t iseg = 0; iseg< basisfunctions.size(); iseg++){
       /* Iterate over carrier frequencies */
-      for (int f=0; f < carrier_freq.size(); f++) {
+      for (size_t f=0; f < carrier_freq.size(); f++) {
         // pass the portion of the gradient that corresponds to this oscillator
         basisfunctions[iseg]->computeVariation_diff(grad+skip_to_oscillator, params, var_reg_bar, f);
      }
@@ -279,13 +279,13 @@ int Oscillator::evalControl(const double t, double* Re_ptr, double* Im_ptr){
   /* Evaluate p(t) and q(t) using the parameters */
   if (params.size()>0) {
     // Iterate over basis parameterizations. Only one will be used, see the break-statement. 
-    for (int bs = 0; bs < basisfunctions.size(); bs++){
+    for (size_t bs = 0; bs < basisfunctions.size(); bs++){
       if (basisfunctions[bs]->getTstart() <= t && 
           basisfunctions[bs]->getTstop() >= t ) {
         /* Iterate over carrier frequencies */
         double sum_p = 0.0;
         double sum_q = 0.0;
-        for (int f=0; f < carrier_freq.size(); f++) {
+        for (size_t f=0; f < carrier_freq.size(); f++) {
           double Blt1 = 0.0; 
           double Blt2 = 0.0;
           basisfunctions[bs]->evaluate(t, params, f, &Blt1, &Blt2);
@@ -309,7 +309,7 @@ int Oscillator::evalControl(const double t, double* Re_ptr, double* Im_ptr){
   } 
 
   /* If pipulse: Overwrite controls by constant amplitude */
-  for (int ipulse=0; ipulse< pipulse.tstart.size(); ipulse++){
+  for (size_t ipulse=0; ipulse< pipulse.tstart.size(); ipulse++){
     if (pipulse.tstart[ipulse] <= t && t <= pipulse.tstop[ipulse]) {
       double amp_pq =  pipulse.amp[ipulse] / sqrt(2.0);
       *Re_ptr = amp_pq;
@@ -331,11 +331,11 @@ int Oscillator::evalControl_diff(const double t, double* dRedp, double* dImdp) {
 
   if (params.size()>0) {
     // Iterate over basis parameterizations
-    for (int bs = 0; bs < basisfunctions.size(); bs++){
+    for (size_t bs = 0; bs < basisfunctions.size(); bs++){
       if (basisfunctions[bs]->getTstart() <= t && 
           basisfunctions[bs]->getTstop() >= t ) {
         /* Iterate over carrier frequencies */
-        for (int f=0; f < carrier_freq.size(); f++) {
+        for (size_t f=0; f < carrier_freq.size(); f++) {
 
           if (basisfunctions[bs]->getType() == ControlType::BSPLINEAMP) {
             basisfunctions[bs]->derivative(t, params, dRedp, carrier_freq[f], 1.0, f);  // +/-1.0 is used as a flag inside Bsline2ndAmplitude->evaluate() to determine whether this is for p (1.0) or for q (-1.0)
@@ -353,7 +353,7 @@ int Oscillator::evalControl_diff(const double t, double* dRedp, double* dImdp) {
   } 
 
   /* TODO: Derivative of pipulse? */
-  for (int ipulse=0; ipulse< pipulse.tstart.size(); ipulse++){
+  for (size_t ipulse=0; ipulse< pipulse.tstart.size(); ipulse++){
     if (pipulse.tstart[ipulse] <= t && t <= pipulse.tstop[ipulse]) {
       printf("ERROR: Derivative of pipulse not implemented. Sorry! But also, this should never happen!\n");
       exit(1);
@@ -375,13 +375,13 @@ int Oscillator::evalControl_Labframe(const double t, double* f){
   *f = 0.0;
   if (params.size()>0) {
     // Iterate over basis parameterizations
-    for (int bs = 0; bs < basisfunctions.size(); bs++){
+    for (size_t bs = 0; bs < basisfunctions.size(); bs++){
       if (basisfunctions[bs]->getTstart() <= t && 
           basisfunctions[bs]->getTstop() >= t ) {
         /* Iterate over carrier frequencies multiply with basisfunction of index k0 */
         double sum_p = 0.0;
         double sum_q = 0.0;
-        for (int f=0; f < carrier_freq.size(); f++) {
+        for (size_t f=0; f < carrier_freq.size(); f++) {
           double cos_omt = cos(carrier_freq[f]*t);
           double sin_omt = sin(carrier_freq[f]*t);
           double Blt1 = 0.0; 
@@ -399,7 +399,7 @@ int Oscillator::evalControl_Labframe(const double t, double* f){
 
 
   /* If inside a pipulse, overwrite lab control */
-  for (int ipulse=0; ipulse< pipulse.tstart.size(); ipulse++){
+  for (size_t ipulse=0; ipulse< pipulse.tstart.size(); ipulse++){
     if (pipulse.tstart[ipulse] <= t && t <= pipulse.tstop[ipulse]) {
       double p = pipulse.amp[ipulse] / sqrt(2.0);
       double q = pipulse.amp[ipulse] / sqrt(2.0);
@@ -503,7 +503,7 @@ void Oscillator::population(const Vec x, std::vector<double> &pop) {
   int dimN = dim_preOsc * nlevels * dim_postOsc;
   double val;
 
-  assert (pop.size() == nlevels);
+  assert (pop.size() == static_cast<size_t>(nlevels));
 
   std::vector<double> mypop(nlevels, 0.0);
 
@@ -543,6 +543,6 @@ void Oscillator::population(const Vec x, std::vector<double> &pop) {
   } 
 
   /* Gather poppulation from all Petsc processors */
-  for (int i=0; i<mypop.size(); i++) {pop[i] = mypop[i];}
+  for (size_t i=0; i<mypop.size(); i++) {pop[i] = mypop[i];}
   MPI_Allreduce(mypop.data(), pop.data(), nlevels, MPI_DOUBLE, MPI_SUM, PETSC_COMM_WORLD);
 }

--- a/src/oscillator.cpp
+++ b/src/oscillator.cpp
@@ -463,7 +463,7 @@ void Oscillator::expectedEnergy_diff(const Vec x, Vec x_bar, const double obj_ba
   int dimmat;
   if (lindbladtype != LindbladType::NONE) dimmat = (int) sqrt(dim/2);
   else dimmat = (int) dim/2;
-  double num_diag, xdiag, val;
+  double xdiag, val;
 
   /* Get locally owned portion of x */
   PetscInt ilow, iupp, idx_diag_re, idx_diag_im;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -45,8 +45,8 @@ Output::Output(MapParam& config, MPI_Comm comm_petsc, MPI_Comm comm_init, int no
 
   /* Search through outputstrings to see if any oscillator contains "fullstate" */
   writefullstate = false;
-  for (int i=0; i<outputstr.size(); i++) {
-    for (int j=0; j<outputstr[i].size(); j++) {
+  for (size_t i=0; i<outputstr.size(); i++) {
+    for (size_t j=0; j<outputstr[i].size(); j++) {
       if (outputstr[i][j].compare("fullstate") == 0 ) writefullstate = true;
     }
   }
@@ -54,8 +54,8 @@ Output::Output(MapParam& config, MPI_Comm comm_petsc, MPI_Comm comm_init, int no
   /* Prepare data output files */
   ufile = NULL;
   vfile = NULL;
-  for (int i=0; i< outputstr.size(); i++) expectedfile.push_back (NULL);
-  for (int i=0; i< outputstr.size(); i++) populationfile.push_back (NULL);
+  for (size_t i=0; i< outputstr.size(); i++) expectedfile.push_back (NULL);
+  for (size_t i=0; i< outputstr.size(); i++) populationfile.push_back (NULL);
   expectedfile_comp=NULL;
   populationfile_comp=NULL;
 
@@ -125,8 +125,8 @@ void Output::writeControls(Vec params, MasterEq* mastereq, int ntime, double dt)
 
     /* Print control to file for each oscillator */
     mastereq->setControlAmplitudes(params);
-    for (int ioscil = 0; ioscil < mastereq->getNOscillators(); ioscil++) {
-      snprintf(filename, 254, "%s/control%d.dat", datadir.c_str(), ioscil);
+    for (size_t ioscil = 0; ioscil < mastereq->getNOscillators(); ioscil++) {
+      snprintf(filename, 254, "%s/control%zu.dat", datadir.c_str(), ioscil);
       file_c = fopen(filename, "w");
       fprintf(file_c, "#\"time\"         \"p(t) (rotating)\"          \"q(t) (rotating)\"         \"f(t) (labframe)\"\n");
 
@@ -165,16 +165,16 @@ void Output::openDataFiles(std::string prefix, int initid){
   bool writeExpComp = false;
   bool writePopComp = false;
   if (mpirank_petsc == 0) {
-    for (int i=0; i<outputstr.size(); i++) {
-      for (int j=0; j<outputstr[i].size(); j++) {
+    for (size_t i=0; i<outputstr.size(); i++) {
+      for (size_t j=0; j<outputstr[i].size(); j++) {
         if (outputstr[i][j].compare("expectedEnergy") == 0) {
-          snprintf(filename, 254, "%s/expected%d.iinit%04d.dat", datadir.c_str(), i, initid);
+          snprintf(filename, 254, "%s/expected%zu.iinit%04d.dat", datadir.c_str(), i, initid);
           expectedfile[i] = fopen(filename, "w");
           fprintf(expectedfile[i], "#\"time\"      \"expected energy level\"\n");
         }
         if (outputstr[i][j].compare("expectedEnergyComposite") == 0) writeExpComp = true;
         if (outputstr[i][j].compare("population") == 0) {
-          snprintf(filename, 254, "%s/population%d.iinit%04d.dat", datadir.c_str(), i, initid);
+          snprintf(filename, 254, "%s/population%zu.iinit%04d.dat", datadir.c_str(), i, initid);
           populationfile[i] = fopen(filename, "w");
           fprintf(populationfile[i], "#\"time\"      \"diagonal of the density matrix\"\n");
         }
@@ -202,7 +202,7 @@ void Output::writeDataFiles(int timestep, double time, const Vec state, MasterEq
   if (timestep % output_frequency == 0) {
 
     /* Write expected energy levels to file */
-    for (int iosc = 0; iosc < expectedfile.size(); iosc++) {
+    for (size_t iosc = 0; iosc < expectedfile.size(); iosc++) {
       if (expectedfile[iosc] != NULL) {
         double expected = mastereq->getOscillator(iosc)->expectedEnergy(state);
         fprintf(expectedfile[iosc], "%.8f %1.14e\n", time, expected);
@@ -215,12 +215,12 @@ void Output::writeDataFiles(int timestep, double time, const Vec state, MasterEq
     }
 
     /* Write population to file */
-    for (int iosc = 0; iosc < populationfile.size(); iosc++) {
+    for (size_t iosc = 0; iosc < populationfile.size(); iosc++) {
       if (populationfile[iosc] != NULL) {
         std::vector<double> pop (mastereq->getOscillator(iosc)->getNLevels(), 0.0);
         mastereq->getOscillator(iosc)->population(state, pop);
         fprintf(populationfile[iosc], "%.8f ", time);
-        for (int i = 0; i<pop.size(); i++) {
+        for (size_t i = 0; i<pop.size(); i++) {
           fprintf(populationfile[iosc], " %1.14e", pop[i]);
         }
         fprintf(populationfile[iosc], "\n");
@@ -231,7 +231,7 @@ void Output::writeDataFiles(int timestep, double time, const Vec state, MasterEq
       std::vector<double> population_comp; 
       mastereq->population(state, population_comp);
       fprintf(populationfile_comp, "%.8f  ", time);
-      for (int i=0; i<population_comp.size(); i++){
+      for (size_t i=0; i<population_comp.size(); i++){
         fprintf(populationfile_comp, "%1.14e  ", population_comp[i]);
       }
       fprintf(populationfile_comp, "\n");
@@ -279,7 +279,7 @@ void Output::closeDataFiles(){
     fclose(vfile);
     vfile = NULL;
   }
-  for (int i=0; i< expectedfile.size(); i++) {
+  for (size_t i=0; i< expectedfile.size(); i++) {
     if (expectedfile[i] != NULL) {
       fclose(expectedfile[i]);
       expectedfile[i] = NULL;
@@ -287,7 +287,7 @@ void Output::closeDataFiles(){
   }
   if (expectedfile_comp != NULL) fclose(expectedfile_comp);
   expectedfile_comp = NULL;
-  for (int i=0; i< populationfile.size(); i++) {
+  for (size_t i=0; i< populationfile.size(); i++) {
     if (populationfile[i] != NULL) {
       fclose(populationfile[i]);
       populationfile[i] = NULL;

--- a/src/pythoninterface.cpp
+++ b/src/pythoninterface.cpp
@@ -48,7 +48,7 @@ void PythonInterface::receiveHsys(Mat& Bd){
   MPI_Bcast(vals.data(), nelems, MPI_DOUBLE, 0, MPI_COMM_WORLD);
 
   /* Iterate over all elements*/
-  for (int i = 0; i<vals.size(); i++) {
+  for (size_t i = 0; i<vals.size(); i++) {
     if (fabs(vals[i])<1e-14) continue; // Skip zeros
 
     // Get position in the Bd matrix
@@ -111,7 +111,7 @@ void PythonInterface::receiveHc(int noscillators, std::vector<std::vector<Mat>>&
 
     // Iterate over received elements and place into Bc_vec
     MatGetOwnershipRange(Bc_vec[k][0], &ilow, &iupp);
-    for (int l = 0; l<vals.size(); l++) {
+    for (size_t l = 0; l<vals.size(); l++) {
       if (fabs(vals[l])<1e-14) continue; // Skip zeros
 
       // Get position in the Bc matrix
@@ -153,7 +153,7 @@ void PythonInterface::receiveHc(int noscillators, std::vector<std::vector<Mat>>&
 
     // Iterate over received vals and place into Ac_vec
     MatGetOwnershipRange(Ac_vec[k][0], &ilow, &iupp);
-    for (int l = 0; l<vals.size(); l++) {
+    for (size_t l = 0; l<vals.size(); l++) {
       if (fabs(vals[l])<1e-14) continue; // Skip zeros
 
       // Get position in the Ac matrix

--- a/src/pythoninterface.cpp
+++ b/src/pythoninterface.cpp
@@ -86,8 +86,6 @@ void PythonInterface::receiveHc(int noscillators, std::vector<std::vector<Mat>>&
 
   /* Get the dimensions right */
   int sqdim = dim_rho; //  N!
-  int dim = dim_rho;
-  if (lindbladtype !=LindbladType::NONE) dim = dim_rho*dim_rho;
   int nelems = dim_rho*dim_rho;
 
   // Skip first Hd lines in the file

--- a/src/timestepper.cpp
+++ b/src/timestepper.cpp
@@ -12,7 +12,7 @@ TimeStepper::TimeStepper() {
   writeDataFiles = false;
 }
 
-TimeStepper::TimeStepper(MapParam config, MasterEq* mastereq_, int ntime_, double total_time_, Output* output_, bool storeFWD_) : TimeStepper() {
+TimeStepper::TimeStepper(MasterEq* mastereq_, int ntime_, double total_time_, Output* output_, bool storeFWD_) : TimeStepper() {
   mastereq = mastereq_;
   dim = 2*mastereq->getDim(); // will be either N^2 (Lindblad) or N (Schroedinger)
   ntime = ntime_;
@@ -521,7 +521,7 @@ void TimeStepper::energyPenaltyIntegral_diff(double time, double penaltybar, Vec
 
 void TimeStepper::evolveBWD(const double tstart, const double tstop, const Vec x_stop, Vec x_adj, Vec grad, bool compute_gradient){}
 
-ExplEuler::ExplEuler(MapParam config, MasterEq* mastereq_, int ntime_, double total_time_, Output* output_, bool storeFWD_) : TimeStepper(config, mastereq_, ntime_, total_time_, output_, storeFWD_) {
+ExplEuler::ExplEuler(MasterEq* mastereq_, int ntime_, double total_time_, Output* output_, bool storeFWD_) : TimeStepper(mastereq_, ntime_, total_time_, output_, storeFWD_) {
   MatCreateVecs(mastereq->getRHS(), &stage, NULL);
   VecZeroEntries(stage);
 }
@@ -560,7 +560,7 @@ void ExplEuler::evolveBWD(const double tstop,const  double tstart,const  Vec x, 
 
 }
 
-ImplMidpoint::ImplMidpoint(MapParam config,MasterEq* mastereq_, int ntime_, double total_time_, LinearSolverType linsolve_type_, int linsolve_maxiter_, Output* output_, bool storeFWD_) : TimeStepper(config, mastereq_, ntime_, total_time_, output_, storeFWD_) {
+ImplMidpoint::ImplMidpoint(MasterEq* mastereq_, int ntime_, double total_time_, LinearSolverType linsolve_type_, int linsolve_maxiter_, Output* output_, bool storeFWD_) : TimeStepper(mastereq_, ntime_, total_time_, output_, storeFWD_) {
 
   /* Create and reset the intermediate vectors */
   MatCreateVecs(mastereq->getRHS(), &stage, NULL);
@@ -770,7 +770,7 @@ int ImplMidpoint::NeumannSolve(Mat A, Vec b, Vec y, double alpha, bool transpose
 
 
 
-CompositionalImplMidpoint::CompositionalImplMidpoint(MapParam config, int order_, MasterEq* mastereq_, int ntime_, double total_time_, LinearSolverType linsolve_type_, int linsolve_maxiter_, Output* output_, bool storeFWD_): ImplMidpoint(config, mastereq_, ntime_, total_time_, linsolve_type_, linsolve_maxiter_, output_, storeFWD_) {
+CompositionalImplMidpoint::CompositionalImplMidpoint(int order_, MasterEq* mastereq_, int ntime_, double total_time_, LinearSolverType linsolve_type_, int linsolve_maxiter_, Output* output_, bool storeFWD_): ImplMidpoint(mastereq_, ntime_, total_time_, linsolve_type_, linsolve_maxiter_, output_, storeFWD_) {
 
   order = order_;
 

--- a/src/timestepper.cpp
+++ b/src/timestepper.cpp
@@ -377,7 +377,6 @@ void TimeStepper::penaltyDpDm_diff(int n, Vec xbar, double Jbar){
     int vecID_re, vecID_im;
 
     const PetscScalar *xptr, *xm1ptr, *xm2ptr, *xp1ptr, *xp2ptr;
-    PetscScalar *xbarptr;
     Vec x, xm1, xm2, xp1, xp2;
 
     int k = ntime - n;
@@ -603,7 +602,6 @@ ImplMidpoint::~ImplMidpoint(){
   if (linsolve_counter <= 0) linsolve_counter = 1;
   linsolve_iterstaken_avg = (int) linsolve_iterstaken_avg / linsolve_counter;
   linsolve_error_avg = linsolve_error_avg / linsolve_counter;
-  int myrank;
   // MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
   // if (myrank == 0) printf("Linear solver type %d: Average iterations = %d, average error = %1.2e\n", linsolve_type, linsolve_iterstaken_avg, linsolve_error_avg);
 

--- a/src/timestepper.cpp
+++ b/src/timestepper.cpp
@@ -518,7 +518,7 @@ void TimeStepper::energyPenaltyIntegral_diff(double time, double penaltybar, Vec
   delete [] cols;
 }
 
-void TimeStepper::evolveBWD(const double tstart, const double tstop, const Vec x_stop, Vec x_adj, Vec grad, bool compute_gradient){}
+void TimeStepper::evolveBWD(const double /*tstart*/, const double /*tstop*/, const Vec /*x_stop*/, Vec /*x_adj*/, Vec /*grad*/, bool /*compute_gradient*/){}
 
 ExplEuler::ExplEuler(MasterEq* mastereq_, int ntime_, double total_time_, Output* output_, bool storeFWD_) : TimeStepper(mastereq_, ntime_, total_time_, output_, storeFWD_) {
   MatCreateVecs(mastereq->getRHS(), &stage, NULL);

--- a/src/timestepper.cpp
+++ b/src/timestepper.cpp
@@ -167,7 +167,7 @@ Vec TimeStepper::solveODE(int initid, Vec rho_t0){
 }
 
 
-void TimeStepper::solveAdjointODE(int initid, Vec rho_t0_bar, Vec finalstate, double Jbar_penalty, double Jbar_penalty_dpdm, double Jbar_energy_penalty) {
+void TimeStepper::solveAdjointODE(Vec rho_t0_bar, Vec finalstate, double Jbar_penalty, double Jbar_penalty_dpdm, double Jbar_energy_penalty) {
 
   /* Reset gradient */
   VecZeroEntries(redgrad);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,5 +1,7 @@
 #include "util.hpp"
 
+// Suppress compiler warnings about unused parameters in code with #ifdef
+#define UNUSED(expr) (void)(expr)
 
 double sigmoid(double width, double x){
   return 1.0 / ( 1.0 + exp(-width*x) );
@@ -541,6 +543,11 @@ int read_vector(const char *filename, double *var, int dim, bool quietmode, int 
 
 /* Compute eigenvalues */
 int getEigvals(const Mat A, const int neigvals, std::vector<double>& eigvals, std::vector<Vec>& eigvecs){
+
+UNUSED(A);
+UNUSED(neigvals);
+UNUSED(eigvals);
+UNUSED(eigvecs);
 
 int nconv = 0;
 #ifdef WITH_SLEPC

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -78,10 +78,10 @@ int mapEssToFull(const int i, const std::vector<int> &nlevels, const std::vector
 
   int id = 0;
   int index = i;
-  for (int iosc = 0; iosc<nlevels.size()-1; iosc++){
+  for (size_t iosc = 0; iosc<nlevels.size()-1; iosc++){
     int postdim = 1;
     int postdim_ess = 1;
-    for (int j = iosc+1; j<nlevels.size(); j++){
+    for (size_t j = iosc+1; j<nlevels.size(); j++){
       postdim *= nlevels[j];
       postdim_ess *= nessential[j];
     }
@@ -100,10 +100,10 @@ int mapFullToEss(const int i, const std::vector<int> &nlevels, const std::vector
 
   int id = 0;
   int index = i;
-  for (int iosc = 0; iosc<nlevels.size(); iosc++){
+  for (size_t iosc = 0; iosc<nlevels.size(); iosc++){
     int postdim = 1;
     int postdim_ess = 1;
-    for (int j = iosc+1; j<nlevels.size(); j++){
+    for (size_t j = iosc+1; j<nlevels.size(); j++){
       postdim *= nlevels[j];
       postdim_ess *= nessential[j];
     }
@@ -160,10 +160,10 @@ int isEssential(const int i, const std::vector<int> &nlevels, const std::vector<
 
   int isEss = 1;
   int index = i;
-  for (int iosc = 0; iosc < nlevels.size(); iosc++){
+  for (size_t iosc = 0; iosc < nlevels.size(); iosc++){
 
     int postdim = 1;
-    for (int j = iosc+1; j<nlevels.size(); j++){
+    for (size_t j = iosc+1; j<nlevels.size(); j++){
       postdim *= nlevels[j];
     }
     int itest = (int) index / postdim;
@@ -181,10 +181,10 @@ int isEssential(const int i, const std::vector<int> &nlevels, const std::vector<
 int isGuardLevel(const int i, const std::vector<int> &nlevels, const std::vector<int> &nessential){
   int isGuard =  0;
   int index = i;
-  for (int iosc = 0; iosc < nlevels.size(); iosc++){
+  for (size_t iosc = 0; iosc < nlevels.size(); iosc++){
 
     int postdim = 1;
-    for (int j = iosc+1; j<nlevels.size(); j++){
+    for (size_t j = iosc+1; j<nlevels.size(); j++){
       postdim *= nlevels[j];
     }
     int itest = (int) index / postdim;   // floor(i/n_post)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -11,13 +11,10 @@ double sigmoid_diff(double width, double x){
 
 double getRampFactor(const double time, const double tstart, const double tstop, const double tramp){
 
-    double eps = 1e-4; // Cutoff for sigmoid ramp 
-    double steep = log(1./eps - 1.) * 2. / tramp; // steepness of sigmoid such that ramp(x) small for x < - tramp/2
     // printf("steep eval %f\n", steep);
 
     double rampfactor = 0.0;
     if (time <= tstart + tramp) { // ramp up
-      double center = tstart + tramp/2.0;
       // rampfactor = sigmoid(steep, time - center);
       rampfactor =  1.0/tramp * time - tstart/ tramp;
     }
@@ -26,7 +23,6 @@ double getRampFactor(const double time, const double tstart, const double tstop,
       rampfactor = 1.0;
     }
     else if (time >= tstop - tramp && time <= tstop) { // down
-      double center = tstop - tramp/2.0;
       // rampfactor = sigmoid(steep, -(time - center));
       // steep = 1842.048073;
       // steep = 1000.0;
@@ -41,8 +37,6 @@ double getRampFactor(const double time, const double tstart, const double tstop,
 
 double getRampFactor_diff(const double time, const double tstart, const double tstop, const double tramp){
 
-    double eps = 1e-4; // Cutoff for sigmoid ramp 
-    double steep = log(1./eps - 1.) * 2. / tramp; // steepness of sigmoid such that ramp(x) small for x < - tramp/2
     // printf("steep der %f\n", steep);
 
     double dramp_dtstop= 0.0;
@@ -54,7 +48,6 @@ double getRampFactor_diff(const double time, const double tstart, const double t
       dramp_dtstop = 0.0;
     }
     else if (time >= tstop - tramp && time <= tstop) { // down
-      double center = tstop - tramp/2.0;
       // dramp_dtstop = sigmoid_diff(steep, -(time - center));
       // steep = 1842.048073;
       dramp_dtstop = 1.0/tramp;
@@ -213,8 +206,6 @@ PetscErrorCode Ikron(const Mat A,const  int dimI, const double alpha, Mat *Out, 
     PetscInt* shiftcols;
     PetscScalar* vals;
     PetscInt dimA;
-    PetscInt dimOut;
-    PetscInt nonzeroOut;
     PetscInt rowID;
 
     MatGetSize(A, &dimA, NULL);
@@ -255,10 +246,7 @@ PetscErrorCode kronI(const Mat A, const int dimI, const double alpha, Mat *Out, 
     PetscInt rowid;
     PetscInt colid;
     PetscScalar insertval;
-    PetscInt dimOut;
-    PetscInt nonzeroOut;
     PetscInt ncols;
-    MatInfo Ainfo;
     MatGetSize(A, &dimA, NULL);
 
     ierr = PetscMalloc1(dimA, &cols); CHKERRQ(ierr);
@@ -493,7 +481,6 @@ PetscErrorCode SanityTests(Vec x, double time){
 int read_vector(const char *filename, double *var, int dim, bool quietmode, int skiplines, const std::string testheader) {
 
   FILE *file;
-  double tmp;
   int success = 0;
 
   file = fopen(filename, "r");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -13,10 +13,13 @@ double sigmoid_diff(double width, double x){
 
 double getRampFactor(const double time, const double tstart, const double tstop, const double tramp){
 
+    // double eps = 1e-4; // Cutoff for sigmoid ramp 
+    // double steep = log(1./eps - 1.) * 2. / tramp; // steepness of sigmoid such that ramp(x) small for x < - tramp/2
     // printf("steep eval %f\n", steep);
 
     double rampfactor = 0.0;
     if (time <= tstart + tramp) { // ramp up
+      // double center = tstart + tramp/2.0;
       // rampfactor = sigmoid(steep, time - center);
       rampfactor =  1.0/tramp * time - tstart/ tramp;
     }
@@ -25,6 +28,7 @@ double getRampFactor(const double time, const double tstart, const double tstop,
       rampfactor = 1.0;
     }
     else if (time >= tstop - tramp && time <= tstop) { // down
+      // double center = tstop - tramp/2.0;
       // rampfactor = sigmoid(steep, -(time - center));
       // steep = 1842.048073;
       // steep = 1000.0;
@@ -39,6 +43,8 @@ double getRampFactor(const double time, const double tstart, const double tstop,
 
 double getRampFactor_diff(const double time, const double tstart, const double tstop, const double tramp){
 
+    // double eps = 1e-4; // Cutoff for sigmoid ramp 
+    // double steep = log(1./eps - 1.) * 2. / tramp; // steepness of sigmoid such that ramp(x) small for x < - tramp/2
     // printf("steep der %f\n", steep);
 
     double dramp_dtstop= 0.0;
@@ -50,6 +56,7 @@ double getRampFactor_diff(const double time, const double tstart, const double t
       dramp_dtstop = 0.0;
     }
     else if (time >= tstop - tramp && time <= tstop) { // down
+      // double center = tstop - tramp/2.0;
       // dramp_dtstop = sigmoid_diff(steep, -(time - center));
       // steep = 1842.048073;
       dramp_dtstop = 1.0/tramp;
@@ -208,6 +215,8 @@ PetscErrorCode Ikron(const Mat A,const  int dimI, const double alpha, Mat *Out, 
     PetscInt* shiftcols;
     PetscScalar* vals;
     PetscInt dimA;
+    // PetscInt dimOut;
+    // PetscInt nonzeroOut;
     PetscInt rowID;
 
     MatGetSize(A, &dimA, NULL);
@@ -248,7 +257,10 @@ PetscErrorCode kronI(const Mat A, const int dimI, const double alpha, Mat *Out, 
     PetscInt rowid;
     PetscInt colid;
     PetscScalar insertval;
+    // PetscInt dimOut;
+    // PetscInt nonzeroOut;
     PetscInt ncols;
+    // MatInfo Ainfo;
     MatGetSize(A, &dimA, NULL);
 
     ierr = PetscMalloc1(dimA, &cols); CHKERRQ(ierr);


### PR DESCRIPTION
This PR re-enables compiler warnings and fixes them. The types of fixes are unused parameters/ variables, unsigned/signed comparisons, a deprecated Petsc function, and uninitialized variables. It may be easier to review by looking through the individual commits-- I tried to keep similar fixes all together.