### PR TITLE
Add environment variable for output directory

### DIFF
--- a/.ci-scripts/build_and_test.sh
+++ b/.ci-scripts/build_and_test.sh
@@ -263,7 +263,7 @@ then
     timed_message "Run regression tests"
 
     mpi_exe=$(grep 'MPIEXEC_EXECUTABLE' "${hostconfig_path}" | cut -d'"' -f2 | sed 's/;/ /g')
-    pytest -v -s tests/regression --mpi-exec="${mpi_exe}"
+    pytest -v -s -m regression --mpi-exec="${mpi_exe}"
 
     timed_message "Quandary tests completed"
 fi
@@ -284,7 +284,7 @@ then
     timed_message "Run performance tests"
 
     mpi_exe=$(grep 'MPIEXEC_EXECUTABLE' "${hostconfig_path}" | cut -d'"' -f2 | sed 's/;/ /g')
-    pytest -v -s tests/performance --mpi-exec="${mpi_exe}" --benchmark-json=benchmark_results.json
+    pytest -v -s -m performance --mpi-exec="${mpi_exe}" --benchmark-json=benchmark_results.json
 
     timed_message "Quandary performance tests completed"
 fi

--- a/.pytest.ini
+++ b/.pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
 addopts = --ignore=blt --ignore=uberenv_libs
 
+markers =
+    regression: mark a test as a regression test
+    performance: mark a test as a performance test
+

--- a/README.md
+++ b/README.md
@@ -125,10 +125,19 @@ The `examples/` folder exemplifies the usage of Quandary's Python interface.
 
 # Tests
 
+
 ## Regression tests
-Regression tests are defined in `tests/regression` and can be run with
+Regression tests are defined in `tests/regression` and `tests/python` directories.
+
+You can run all regression tests with:
+```bash
+pytest -m regression
 ```
+
+Or run tests in a specific directory:
+```bash
 pytest tests/regression
+pytest tests/python
 ```
 See `tests/regression/README.md` for more information.
 

--- a/quandary.py
+++ b/quandary.py
@@ -1051,15 +1051,24 @@ def resolve_datadir(datadir: str) -> str:
     Returns:
     -------
     Resolved absolute or relative path for the data directory
+
+    Raises:
+    ------
+    ValueError: If QUANDARY_BASE_DATADIR is set but doesn't exist or isn't a directory
     """
     if os.path.isabs(datadir):
         return datadir
 
     base_dir = os.environ.get("QUANDARY_BASE_DATADIR")
     if base_dir:
+        if not os.path.exists(base_dir):
+            raise ValueError(f"Environment variable QUANDARY_BASE_DATADIR points to non-existent path: {base_dir}")
+        if not os.path.isdir(base_dir):
+            raise ValueError(f"Environment variable QUANDARY_BASE_DATADIR is not a directory: {base_dir}")
+
         datadir = os.path.join(base_dir, datadir)
 
-    return datadir
+    return os.path.normpath(datadir)
 
 
 def hamiltonians(*, N, freq01, selfkerr, crosskerr=[], Jkl = [], rotfreq=[], verbose=True):

--- a/tests/performance/performance_test.py
+++ b/tests/performance/performance_test.py
@@ -7,6 +7,9 @@ import pytest
 from pydantic import BaseModel, TypeAdapter
 from tests.utils.common import build_mpi_command
 
+# Mark all tests in this file as performance tests
+pytestmark = pytest.mark.performance
+
 TEST_PATH = os.path.dirname(os.path.realpath(__file__))
 TEST_CASES_PATH = os.path.join(TEST_PATH, "test_cases.json")
 TEST_CONFIG_PATH = os.path.join(TEST_PATH, "configs")

--- a/tests/python/test_env_variable.py
+++ b/tests/python/test_env_variable.py
@@ -96,6 +96,35 @@ def test_absolute_output_path_with_env_var(quandary, request, tmp_path, clean_en
     assert not os.path.exists(os.environ[BASE_DATADIR])
 
 
+@pytest.mark.parametrize("quandary", test_cases)
+def test_nonexistent_base_directory(quandary, tmp_path, clean_env_var):
+    nonexistent_path = os.path.join(tmp_path, "nonexistent_directory")
+    os.environ[BASE_DATADIR] = nonexistent_path
+    datadir_name = "some_output_dir"
+
+    with pytest.raises(ValueError) as excinfo:
+        quandary(datadir=datadir_name)
+
+    assert "non-existent path" in str(excinfo.value)
+    assert nonexistent_path in str(excinfo.value)
+
+
+@pytest.mark.parametrize("quandary", test_cases)
+def test_file_as_base_directory(quandary, tmp_path, clean_env_var):
+    file_path = os.path.join(tmp_path, "this_is_a_file.txt")
+    with open(file_path, 'w') as f:
+        f.write("This is a file, not a directory")
+
+    os.environ[BASE_DATADIR] = file_path
+    datadir_name = "some_output_dir"
+
+    with pytest.raises(ValueError) as excinfo:
+        quandary(datadir=datadir_name)
+
+    assert "not a directory" in str(excinfo.value)
+    assert file_path in str(excinfo.value)
+
+
 @pytest.fixture
 def cd_tmp_path(tmp_path):
     """Change to a temporary directory for the test and return afterward."""

--- a/tests/python/test_env_variable.py
+++ b/tests/python/test_env_variable.py
@@ -1,4 +1,3 @@
-import math
 import os
 import pytest
 from quandary import Quandary
@@ -40,6 +39,7 @@ def quandary_optimize(datadir, mpi_exec):
         mpi_exec=mpi_exec,
         maxcores=2
     )
+
 
 test_cases = [
     quandary_optimize,

--- a/tests/python/test_env_variable.py
+++ b/tests/python/test_env_variable.py
@@ -3,6 +3,9 @@ import os
 import pytest
 from quandary import Quandary
 
+# Mark all tests in this file as regression tests
+pytestmark = pytest.mark.regression
+
 BASE_DATADIR = "QUANDARY_BASE_DATADIR"
 
 

--- a/tests/python/test_env_variable.py
+++ b/tests/python/test_env_variable.py
@@ -43,11 +43,6 @@ def test_relative_output_path_without_env_var(quandary, request, cd_tmp_path, cl
 
     quandary(datadir=datadir_name, mpi_exec=mpi_exec)
 
-    print(f"\nCurrent directory: {os.getcwd()}")
-    print(f"Env var: {os.environ.get(BASE_DATADIR)}")
-    print(f"datadir: {datadir_name}")
-    print(f"mpi_exec: {mpi_exec}")
-
     assert_output_files(datadir_path)
 
 
@@ -57,11 +52,6 @@ def test_absolute_output_path_without_env_var(quandary, request, tmp_path, clean
     datadir_path = os.path.join(tmp_path, datadir_name)
 
     quandary(datadir=datadir_path, mpi_exec=mpi_exec)
-
-    print(f"\nCurrent directory: {os.getcwd()}")
-    print(f"Env var: {os.environ.get(BASE_DATADIR)}")
-    print(f"datadir: {datadir_path}")
-    print(f"mpi_exec: {mpi_exec}")
 
     assert_output_files(datadir_path)
 
@@ -75,11 +65,6 @@ def test_relative_output_path_with_env_var(quandary, request, tmp_path, clean_en
 
     quandary(datadir=datadir_name, mpi_exec=mpi_exec)
 
-    print(f"\nCurrent directory: {os.getcwd()}")
-    print(f"Env var: {os.environ.get(BASE_DATADIR)}")
-    print(f"datadir: {datadir_name}")
-    print(f"mpi_exec: {mpi_exec}")
-
     assert_output_files(datadir_path)
 
 
@@ -90,11 +75,6 @@ def test_absolute_output_path_with_env_var(quandary, request, tmp_path, clean_en
     datadir_path = os.path.join(tmp_path, datadir_name)
 
     quandary(datadir=datadir_path, mpi_exec=mpi_exec)
-
-    print(f"\nCurrent directory: {os.getcwd()}")
-    print(f"Env var: {os.environ.get(BASE_DATADIR)}")
-    print(f"datadir: {datadir_path}")
-    print(f"mpi_exec: {mpi_exec}")
 
     assert_output_files(datadir_path)
     assert not os.path.exists(os.environ[BASE_DATADIR])

--- a/tests/python/test_env_variable.py
+++ b/tests/python/test_env_variable.py
@@ -19,19 +19,27 @@ def quandary_simulate(datadir, mpi_exec):
         nsteps=10,
         maxiter=1,
         spline_order=0,
-    ).simulate(datadir=datadir, mpi_exec=mpi_exec)
+    ).simulate(
+        datadir=datadir,
+        mpi_exec=mpi_exec,
+        maxcores=2
+    )
 
 
 def quandary_optimize(datadir, mpi_exec):
     return Quandary(
         Ne=[2],
-        T=100.0,
-        targetstate=[1.0/math.sqrt(2), 1.0/math.sqrt(2)],
-        initialcondition=[1.0, 0.0],
-        tol_infidelity=1e-5,
-        initctrl_MHz=[0.1],
-        rand_seed=1234
-    ).optimize(datadir=datadir, mpi_exec=mpi_exec)
+        targetstate=[0.0, 1.0],
+        initialcondition="basis",
+        tol_infidelity=1e-2,
+        nsteps=1,
+        maxiter=1,
+        spline_order=0
+    ).optimize(
+        datadir=datadir,
+        mpi_exec=mpi_exec,
+        maxcores=2
+    )
 
 test_cases = [
     quandary_optimize,

--- a/tests/regression/regression_test.py
+++ b/tests/regression/regression_test.py
@@ -8,6 +8,9 @@ from typing import List
 
 from tests.utils.common import build_mpi_command
 
+# Mark all tests in this file as regression tests
+pytestmark = pytest.mark.regression
+
 REL_TOL = 1.0e-7
 ABS_TOL = 1.0e-15
 


### PR DESCRIPTION
This PR:

- Adds environment variable `QUANDARY_BASE_DATADIR` to quandary.py to set a base output directory for both the config.cfg and output files. A user can still pass in a `datadir` and (if this is a relative path) this will be evaluated relative to the `QUANDARY_BASE_DATADIR` or if that is unset, then it will use the current working directory. When the environment variable is unset the behavior should be the same as it is currently. As the python code changes directories before executing quandary, it was not necessary to make changes to the C++ code for this.
- Adds tests for this to `tests/python`. These are also regression tests but need to be in their own folder, since the other regression tests rely on the folder structure for test cases.
- Add a `regression` and `performance` test category to pytest to offer an extra way to run the different test subsets in addition to using the folders. `pytest -m regression` will run both the `tests/python` and `tests/regression`. Update docs to explain this.
