### PR TITLE
Minor fixes

### DIFF
--- a/quandary.py
+++ b/quandary.py
@@ -876,7 +876,6 @@ def eigen_and_reorder(H0, verbose=False):
     # Get eigenvalues and vectors and sort them in ascending order
     Ntot = H0.shape[0]
     evals, evects = np.linalg.eig(H0)
-    evects = np.asmatrix(evects) # convert ndarray to matrix ?
     reord = np.argsort(evals)
     evals = evals[reord]
     evects = evects[:,reord]
@@ -936,8 +935,8 @@ def get_resonances(*, Ne, Ng, Hsys, Hc_re=[], Hc_im=[], rotfreq=[], cw_amp_thres
     for q in range(nqubits):
        
         # Transform symmetric and anti-symmetric control Hamiltonians using eigenvectors (reordered)
-        Hsym_trans = Utrans.H @ Hc_re[q] @ Utrans
-        Hanti_trans = Utrans.H @ Hc_im[q] @ Utrans
+        Hsym_trans = Utrans.conj().T @ Hc_re[q] @ Utrans
+        Hanti_trans = Utrans.conj().T @ Hc_im[q] @ Utrans
 
         resonances_a = []
         speed_a = []

--- a/quandary.py
+++ b/quandary.py
@@ -871,7 +871,7 @@ def estimate_timesteps(*, T=1.0, Hsys=[], Hc_re=[], Hc_im=[], maxctrl_MHz=[], Pm
 
 
 def eigen_and_reorder(H0, verbose=False):
-    """ Internal function that computes eigen decomposition and re-orders it to make the eigenvector matrix as close to the identity as posiible """
+    """ Internal function that computes eigen decomposition and re-orders it to make the eigenvector matrix as close to the identity as possible """
 
     # Get eigenvalues and vectors and sort them in ascending order
     Ntot = H0.shape[0]

--- a/tests/regression/regression_test.py
+++ b/tests/regression/regression_test.py
@@ -76,7 +76,7 @@ def run_test(simulation_dir, number_of_processes, config_file, files_to_compare,
 
 def compare_files(file_name, output, expected, exact):
     df_output = pd.read_csv(output, sep="\\s+", header=get_header(output))
-    df_expected = pd.read_csv(expected, sep="\\s+", header=get_header(output))
+    df_expected = pd.read_csv(expected, sep="\\s+", header=get_header(expected))
     pd.testing.assert_frame_equal(df_output, df_expected, rtol=REL_TOL, atol=ABS_TOL, obj=file_name, check_exact=exact)
 
 


### PR DESCRIPTION
This PR:
- Fixes typo
- Fixes copy/paste bug in regression_test.py
- Fixes deprecation warning-- `numpy.ndarray` is recommended over `numpy.matix` which is deprecated. `ndarray` does not have Hermition, so use conjugate transpose instead.