### PR TITLE
Fix macOS GitHub workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,11 @@ jobs:
         spack -e .spack_env mirror set binary_mirror --unsigned
         spack mirror add --type binary --unsigned --oci-username GITHUB_USER --oci-password-variable GITHUB_TOKEN local-buildcache oci://ghcr.io/LLNL/quandary-spack-buildcache
 
+    - name: Add only use GCC on macOS
+      if: runner.os == 'macOS'
+      run: |
+        spack compiler find /opt/homebrew/bin
+
     - name: Install
       # explicitly use openmpi, since mpich causes rpath problems in binary
       run: |


### PR DESCRIPTION
Fix macOS GitHub workflow by avoiding the apple-clang compiler.