### PR TITLE
Bugfix evalControls: update timestepsize to match sampling rate.

### DIFF
--- a/quandary.py
+++ b/quandary.py
@@ -377,7 +377,9 @@ class Quandary:
 
         # Copy original setting and overwrite number of time steps for simulation
         nsteps_org = self.nsteps
+        dT_org = self.dT
         self.nsteps = int(np.floor(self.T * points_per_ns))
+        self.dT = self.T/self.nsteps
     
         datadir = resolve_datadir(datadir)
 
@@ -394,6 +396,7 @@ class Quandary:
     
         # Restore original setting
         self.nsteps = nsteps_org
+        self.dT = dT_org 
 
         return time, pt, qt
 


### PR DESCRIPTION
When evaluating the controls in the python interface, quandary's timestep size (dT) needs to be updated for the required sample rate of the pulses that are to be evaluated. Now the original dT is stored, the new dT for the sample rate overrides the member variable, then runs quandary, then resets to the original timestep size.