### PR TITLE
Make it easier to build with debug or int64 flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,14 @@ project(
     LANGUAGES CXX C
 )
 
+# Set default build type to Release if not specified
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose build type" FORCE)
+endif()
+
 set(BLT_CXX_STD "c++14" CACHE STRING "Version of C++ standard")
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+
 set(ENABLE_MPI ON CACHE BOOL "")
 
 ################################

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ pip install -e .
 #### Optional Spack environment variations
 The Spack environment used to build Quandary is defined in `.spack_env/spack.yaml`.
 You can add or remove packages from the `specs` list as needed or use different variants of these. 
-For instance, if you want to use the debug variant (which builds Petsc in debug mode) you can use `quandary@develop+test+debug`.
+For instance, if you want to use the debug variant (which builds Quandary and Petsc in debug mode) you can use `quandary@develop+test build_type=Debug`.
+To build with `PetscInt`s set to 64-bit integers, use `quandary+int64`.
 To use a specific version of Petsc instead of the latest release, you can do e.g. `quandary@develop^petsc@3.22.1`.
 The `+test` variant (by default on in `.spack_env/spack.yaml`) adds python and pip to the Spack environment.
 This allows `pip install` to install python packages to your Spack virtual environment rather than a global one.
@@ -89,6 +90,7 @@ cmake ..
 make
 ```
 
+To build in debug mode use `cmake -DCMAKE_BUILD_TYPE=Debug ..`.
 Add the path to Quandary to your `PATH` variable with `export PATH=/path/to/quandary/:$PATH`, so your binary can be found.
 Alternatively, you can install the Quandary executable in a specific path (such as the default `/usr/local/bin` to have it in your `PATH` automatically):
 ```


### PR DESCRIPTION
- don't always add `-O3` flag. Instead use CMAKE_BUILD_TYPE which will also add that flag if you set the type to release (default type) and can also set debug flags.
- Update radiuss-spack-configs version to include [changes](https://github.com/LLNL/radiuss-spack-configs/pull/129/files) I made to the Quandary spack package-- style fixes, add int64 variant that uses petsc int64 variant, use petsc debug variant when build_type=Debug

If you want to build in debug mode you can either use the spack spec `quandary build_type=Debug` which automatically uses petsc in debug mode, or with CMake you can do `cmake -DCMAKE_BUILD_TYPE=Debug ..`. With spack you can also choose petsc in 64 bit int mode using `quandary+int64`.