### PR TITLE
Use median in performance tests

### DIFF
--- a/tests/performance/convert_benchmark_format.py
+++ b/tests/performance/convert_benchmark_format.py
@@ -21,7 +21,7 @@ def convert_to_custom_format(pytest_data: Dict[str, Any]) -> List[Dict[str, Any]
         name = benchmark.get("name", "")
 
         # Time benchmark entry
-        time_value = benchmark.get("stats", {}).get("mean", 0)
+        time_value = benchmark.get("stats", {}).get("median", 0)
         time_stddev = benchmark.get("stats", {}).get("stddev", 0)
         custom_benchmarks.append({
             "name": f"{name} - Time",


### PR DESCRIPTION
Use median instead of mean on the benchmark dashboard as this is more resistant to outliers