### PR TITLE
Minor improvement: use const references for vectors

### DIFF
--- a/include/gate.hpp
+++ b/include/gate.hpp
@@ -53,7 +53,7 @@ class Gate {
      * @param lindbladtype_ Type of Lindblad operators for open system dynamics.
      * @param quietmode Flag to suppress output messages (default: false).
      */
-    Gate(std::vector<int> nlevels_, std::vector<int> nessential_, double time_, std::vector<double> gate_rot_freq, LindbladType lindbladtype_, bool quietmode=false);
+    Gate(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time_, const std::vector<double>& gate_rot_freq, LindbladType lindbladtype_, bool quietmode=false);
 
     virtual ~Gate();
 
@@ -95,7 +95,7 @@ class Gate {
  */
 class XGate : public Gate {
   public:
-    XGate(std::vector<int> nlevels_, std::vector<int> nessential_, double time, std::vector<double> rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
+    XGate(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time, const std::vector<double>& rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
     ~XGate();
 };
 
@@ -110,7 +110,7 @@ class XGate : public Gate {
  */
 class YGate : public Gate {
   public:
-    YGate(std::vector<int> nlevels_, std::vector<int> nessential_, double time, std::vector<double> rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
+    YGate(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time, const std::vector<double>& rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
     ~YGate();
 };
 
@@ -125,7 +125,7 @@ class YGate : public Gate {
  */
 class ZGate : public Gate {
   public:
-    ZGate(std::vector<int> nlevels_, std::vector<int> nessential_, double time, std::vector<double> rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
+    ZGate(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time, const std::vector<double>& rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
     ~ZGate();
 };
 
@@ -140,7 +140,7 @@ class ZGate : public Gate {
  */
 class HadamardGate : public Gate {
   public:
-    HadamardGate(std::vector<int> nlevels_, std::vector<int> nessential_, double time, std::vector<double> rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
+    HadamardGate(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time, const std::vector<double>& rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
     ~HadamardGate();
 };
 
@@ -157,7 +157,7 @@ class HadamardGate : public Gate {
  */
 class CNOT : public Gate {
     public:
-    CNOT(std::vector<int> nlevels_, std::vector<int> nessential_, double time, std::vector<double> rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
+    CNOT(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time, const std::vector<double>& rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
     ~CNOT();
 };
 
@@ -174,7 +174,7 @@ class CNOT : public Gate {
  */
 class SWAP: public Gate {
     public:
-    SWAP(std::vector<int> nlevels_, std::vector<int> nessential_, double time, std::vector<double> rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
+    SWAP(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time, const std::vector<double>& rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
     ~SWAP();
 };
 
@@ -187,7 +187,7 @@ class SWAP: public Gate {
  */
 class SWAP_0Q: public Gate {
     public:
-    SWAP_0Q(std::vector<int> nlevels_, std::vector<int> nessential_, double time, std::vector<double> rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
+    SWAP_0Q(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time, const std::vector<double>& rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
     ~SWAP_0Q();
 };
 
@@ -199,7 +199,7 @@ class SWAP_0Q: public Gate {
  */
 class CQNOT: public Gate {
     public:
-    CQNOT(std::vector<int> nlevels_, std::vector<int> nessential_, double time, std::vector<double> rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
+    CQNOT(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time, const std::vector<double>& rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
     ~CQNOT();
 };
 
@@ -210,7 +210,7 @@ class CQNOT: public Gate {
  */
 class QFT: public Gate {
   public:
-    QFT(std::vector<int> nlevels_, std::vector<int> nessential_, double time, std::vector<double> rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
+    QFT(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time, const std::vector<double>& rotation_frequencies_, LindbladType lindbladtype_, bool quietmode=false);
     ~QFT();
 };
 
@@ -232,7 +232,7 @@ class FromFile: public Gate {
      * @param filename Path to file containing gate matrix data.
      * @param quietmode Flag to suppress output messages (default: false).
      */
-    FromFile(std::vector<int> nlevels_, std::vector<int> nessential_, double time, std::vector<double> rotation_frequencies_, LindbladType lindbladtype_, std::string filename, bool quietmode=false);
+    FromFile(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time, const std::vector<double>& rotation_frequencies_, LindbladType lindbladtype_, const std::string& filename, bool quietmode=false);
     ~FromFile();
 };
 
@@ -252,4 +252,4 @@ class FromFile: public Gate {
  * @param quietmode Flag to suppress output messages.
  * @return Gate* Pointer to the initialized gate object.
  */
-Gate* initTargetGate(std::vector<std::string> target_str, std::vector<int>nlevels, std::vector<int>nessential, double total_time, LindbladType lindbladtype, std::vector<double> gate_rot_freq, bool quietmode);
+Gate* initTargetGate(const std::vector<std::string>& target_str, const std::vector<int>& nlevels, const std::vector<int>& nessential, double total_time, LindbladType lindbladtype, const std::vector<double>& gate_rot_freq, bool quietmode);

--- a/include/mastereq.hpp
+++ b/include/mastereq.hpp
@@ -140,7 +140,7 @@ class MasterEq{
      * @param hamiltonian_file Filename for Hamiltonian data
      * @param quietmode Flag for quiet operation (default: false)
      */
-    MasterEq(std::vector<int> nlevels, std::vector<int> nessential, Oscillator** oscil_vec_, const std::vector<double> crosskerr_, const std::vector<double> Jkl_, const std::vector<double> eta_, LindbladType lindbladtype_, bool usematfree_, std::string hamiltonian_file, bool quietmode=false);
+    MasterEq(const std::vector<int>& nlevels, const std::vector<int>& nessential, Oscillator** oscil_vec_, const std::vector<double>& crosskerr_, const std::vector<double>& Jkl_, const std::vector<double>& eta_, LindbladType lindbladtype_, bool usematfree_, const std::string& hamiltonian_file, bool quietmode=false);
 
     ~MasterEq();
 

--- a/include/optimtarget.hpp
+++ b/include/optimtarget.hpp
@@ -56,7 +56,7 @@ class OptimTarget{
      * @param rho_t0 Initial state vector
      * @param quietmode_ Flag for quiet operation
      */
-    OptimTarget(std::vector<std::string> target_str, std::string objective_str, std::vector<std::string> initcond_str, MasterEq* mastereq, double total_time, std::vector<double> read_gate_rot, Vec rho_t0, bool quietmode_);
+    OptimTarget(std::vector<std::string> target_str, const std::string& objective_str, std::vector<std::string> initcond_str, MasterEq* mastereq, double total_time, std::vector<double> read_gate_rot, Vec rho_t0, bool quietmode_);
 
     ~OptimTarget();
 
@@ -84,7 +84,7 @@ class OptimTarget{
      * @param rho0 Vector to store the initial condition
      * @return int Identifier for this initial condition (element number in matrix vectorization)
      */
-    int prepareInitialState(const int iinit, const int ninit, std::vector<int> nlevels, std::vector<int> nessential,  Vec rho0);
+    int prepareInitialState(const int iinit, const int ninit, const std::vector<int>& nlevels, const std::vector<int>& nessential,  Vec rho0);
 
     /**
      * @brief Prepares the target state for gate optimization.

--- a/include/oscillator.hpp
+++ b/include/oscillator.hpp
@@ -92,7 +92,7 @@ class Oscillator {
      * @param lindbladtype_ Type of Lindblad operators
      * @param rand_engine Random number generator engine
      */
-    Oscillator(Config config, size_t id, std::vector<int> nlevels_all_, std::vector<std::string>& controlsegments, std::vector<std::string>& controlinitializations, double ground_freq_, double selfkerr_, double rotational_freq_, double decay_time_, double dephase_time_, std::vector<double> carrier_freq_, double Tfinal_, LindbladType lindbladtype_, std::default_random_engine rand_engine);
+    Oscillator(Config config, size_t id, const std::vector<int>& nlevels_all_, std::vector<std::string>& controlsegments, std::vector<std::string>& controlinitializations, double ground_freq_, double selfkerr_, double rotational_freq_, double decay_time_, double dephase_time_, const std::vector<double>& carrier_freq_, double Tfinal_, LindbladType lindbladtype_, std::default_random_engine rand_engine);
 
     virtual ~Oscillator();
 

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -6,7 +6,7 @@ Gate::Gate(){
   quietmode=false;
 }
 
-Gate::Gate(std::vector<int> nlevels_, std::vector<int> nessential_, double time_, std::vector<double> gate_rot_freq_, LindbladType lindbladtype_, bool quietmode_){
+Gate::Gate(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time_, const std::vector<double>& gate_rot_freq_, LindbladType lindbladtype_, bool quietmode_){
 
   MPI_Comm_rank(PETSC_COMM_WORLD, &mpirank_petsc);
   MPI_Comm_rank(MPI_COMM_WORLD, &mpirank_world);
@@ -283,7 +283,7 @@ void Gate::applyGate(const Vec state, Vec VrhoV){
 }
 
 
-XGate::XGate(std::vector<int> nlevels, std::vector<int> nessential, double time, std::vector<double> gate_rot_freq, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels, nessential, time, gate_rot_freq, lindbladtype_, quietmode) {
+XGate::XGate(const std::vector<int>& nlevels, const std::vector<int>& nessential, double time, const std::vector<double>& gate_rot_freq, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels, nessential, time, gate_rot_freq, lindbladtype_, quietmode) {
 
   assert(dim_ess == 2);
 
@@ -302,7 +302,7 @@ XGate::XGate(std::vector<int> nlevels, std::vector<int> nessential, double time,
 
 XGate::~XGate() {}
 
-YGate::YGate(std::vector<int> nlevels, std::vector<int> nessential, double time, std::vector<double> gate_rot_freq, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels, nessential, time, gate_rot_freq, lindbladtype_, quietmode) {
+YGate::YGate(const std::vector<int>& nlevels, const std::vector<int>& nessential, double time, const std::vector<double>& gate_rot_freq, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels, nessential, time, gate_rot_freq, lindbladtype_, quietmode) {
 
   assert(dim_ess == 2);
   
@@ -320,7 +320,7 @@ YGate::YGate(std::vector<int> nlevels, std::vector<int> nessential, double time,
 }
 YGate::~YGate() {}
 
-ZGate::ZGate(std::vector<int> nlevels, std::vector<int> nessential, double time, std::vector<double> gate_rot_freq, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels, nessential, time, gate_rot_freq, lindbladtype_, quietmode) {
+ZGate::ZGate(const std::vector<int>& nlevels, const std::vector<int>& nessential, double time, const std::vector<double>& gate_rot_freq, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels, nessential, time, gate_rot_freq, lindbladtype_, quietmode) {
 
   assert(dim_ess == 2);
 
@@ -339,7 +339,7 @@ ZGate::ZGate(std::vector<int> nlevels, std::vector<int> nessential, double time,
 
 ZGate::~ZGate() {}
 
-HadamardGate::HadamardGate(std::vector<int> nlevels, std::vector<int> nessential, double time, std::vector<double> gate_rot_freq, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels, nessential, time, gate_rot_freq, lindbladtype_, quietmode) {
+HadamardGate::HadamardGate(const std::vector<int>& nlevels, const std::vector<int>& nessential, double time, const std::vector<double>& gate_rot_freq, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels, nessential, time, gate_rot_freq, lindbladtype_, quietmode) {
 
   assert(dim_ess == 2);
 
@@ -362,7 +362,7 @@ HadamardGate::~HadamardGate() {}
 
 
 
-CNOT::CNOT(std::vector<int> nlevels, std::vector<int> nessential, double time, std::vector<double> gate_rot_freq, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels, nessential,time, gate_rot_freq, lindbladtype_,  quietmode) {
+CNOT::CNOT(const std::vector<int>& nlevels, const std::vector<int>& nessential, double time, const std::vector<double>& gate_rot_freq, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels, nessential,time, gate_rot_freq, lindbladtype_,  quietmode) {
 
   assert(dim_ess == 4);
 
@@ -387,7 +387,7 @@ CNOT::CNOT(std::vector<int> nlevels, std::vector<int> nessential, double time, s
 CNOT::~CNOT(){}
 
 
-SWAP::SWAP(std::vector<int> nlevels_, std::vector<int> nessential_, double time_, std::vector<double> gate_rot_freq_, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels_, nessential_, time_, gate_rot_freq_, lindbladtype_, quietmode) {
+SWAP::SWAP(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time_, const std::vector<double>& gate_rot_freq_, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels_, nessential_, time_, gate_rot_freq_, lindbladtype_, quietmode) {
   assert(dim_ess == 4);
 
   /* Fill lab-frame swap gate in essential dimension system V_re = Re(V), V_im = Im(V) = 0 */
@@ -408,7 +408,7 @@ SWAP::SWAP(std::vector<int> nlevels_, std::vector<int> nessential_, double time_
 
 SWAP::~SWAP(){}
 
-SWAP_0Q::SWAP_0Q(std::vector<int> nlevels_, std::vector<int> nessential_, double time_, std::vector<double> gate_rot_freq_, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels_, nessential_, time_, gate_rot_freq_, lindbladtype_, quietmode) {
+SWAP_0Q::SWAP_0Q(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time_, const std::vector<double>& gate_rot_freq_, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels_, nessential_, time_, gate_rot_freq_, lindbladtype_, quietmode) {
   int Q = nlevels.size();  // Number of total oscillators 
 
   /* Fill lab-frame swap 0<->Q-1 gate in essential dimension system V_re = Re(V), V_im = Im(V) = 0 */
@@ -448,7 +448,7 @@ SWAP_0Q::SWAP_0Q(std::vector<int> nlevels_, std::vector<int> nessential_, double
 SWAP_0Q::~SWAP_0Q(){}
 
 
-CQNOT::CQNOT(std::vector<int> nlevels_, std::vector<int> nessential_, double time_, std::vector<double> gate_rot_freq_, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels_, nessential_, time_, gate_rot_freq_, lindbladtype_, quietmode) {
+CQNOT::CQNOT(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time_, const std::vector<double>& gate_rot_freq_, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels_, nessential_, time_, gate_rot_freq_, lindbladtype_, quietmode) {
 
   /* Fill lab-frame CQNOT gate in essential dimension system V_re = Re(V), V_im = Im(V) = 0 */
   /* V = [1 0 0 ...
@@ -477,7 +477,7 @@ CQNOT::CQNOT(std::vector<int> nlevels_, std::vector<int> nessential_, double tim
 CQNOT::~CQNOT(){}
 
 
-QFT::QFT(std::vector<int> nlevels_, std::vector<int> nessential_, double time_, std::vector<double> gate_rot_freq_, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels_, nessential_, time_, gate_rot_freq_, lindbladtype_, quietmode) {
+QFT::QFT(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time_, const std::vector<double>& gate_rot_freq_, LindbladType lindbladtype_, bool quietmode) : Gate(nlevels_, nessential_, time_, gate_rot_freq_, lindbladtype_, quietmode) {
 
   double sq = sqrt(dim_ess);
 
@@ -502,7 +502,7 @@ QFT::QFT(std::vector<int> nlevels_, std::vector<int> nessential_, double time_, 
 QFT::~QFT(){}
 
 
-FromFile::FromFile(std::vector<int> nlevels_, std::vector<int> nessential_, double time_, std::vector<double> gate_rot_freq_, LindbladType lindbladtype_, std::string filename, bool quietmode) : Gate(nlevels_, nessential_, time_, gate_rot_freq_, lindbladtype_, quietmode){
+FromFile::FromFile(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, double time_, const std::vector<double>& gate_rot_freq_, LindbladType lindbladtype_, const std::string& filename, bool quietmode) : Gate(nlevels_, nessential_, time_, gate_rot_freq_, lindbladtype_, quietmode){
 
   // Read the gate from a file
   int nelems = 2*dim_ess*dim_ess;
@@ -543,7 +543,7 @@ FromFile::FromFile(std::vector<int> nlevels_, std::vector<int> nessential_, doub
 FromFile::~FromFile(){}
 
 
-Gate* initTargetGate(std::vector<std::string> target_str, std::vector<int>nlevels, std::vector<int>nessential, double total_time, LindbladType lindbladtype, std::vector<double> gate_rot_freq, bool quietmode){
+Gate* initTargetGate(const std::vector<std::string>& target_str, const std::vector<int>& nlevels, const std::vector<int>& nessential, double total_time, LindbladType lindbladtype, const std::vector<double>& gate_rot_freq, bool quietmode){
 
   if ( target_str.size() < 2 ) {
     printf("ERROR: You want to optimize for a gate, but didn't specify which one. Check your config for 'optim_target'!\n");

--- a/src/mastereq.cpp
+++ b/src/mastereq.cpp
@@ -11,7 +11,7 @@ MasterEq::MasterEq(){
 }
 
 
-MasterEq::MasterEq(std::vector<int> nlevels_, std::vector<int> nessential_, Oscillator** oscil_vec_, const std::vector<double> crosskerr_, const std::vector<double> Jkl_, const std::vector<double> eta_, LindbladType lindbladtype_, bool usematfree_, std::string hamiltonian_file_, bool quietmode_) {
+MasterEq::MasterEq(const std::vector<int>& nlevels_, const std::vector<int>& nessential_, Oscillator** oscil_vec_, const std::vector<double>& crosskerr_, const std::vector<double>& Jkl_, const std::vector<double>& eta_, LindbladType lindbladtype_, bool usematfree_, const std::string& hamiltonian_file_, bool quietmode_) {
   nlevels = nlevels_;
   nessential = nessential_;
   noscillators = nlevels.size();

--- a/src/optimtarget.cpp
+++ b/src/optimtarget.cpp
@@ -17,7 +17,7 @@ OptimTarget::OptimTarget(){
 }
 
 
-OptimTarget::OptimTarget(std::vector<std::string> target_str, std::string objective_str, std::vector<std::string> initcond_str, MasterEq* mastereq, double total_time, std::vector<double> read_gate_rot, Vec rho_t0, bool quietmode_) : OptimTarget() {
+OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string& objective_str, std::vector<std::string> initcond_str, MasterEq* mastereq, double total_time, std::vector<double> read_gate_rot, Vec rho_t0, bool quietmode_) : OptimTarget() {
 
   // initialize
   dim = mastereq->getDim();
@@ -424,7 +424,7 @@ void OptimTarget::HilbertSchmidtOverlap_diff(const Vec state, Vec statebar, bool
 }
 
 
-int OptimTarget::prepareInitialState(const int iinit, const int ninit, std::vector<int> nlevels, std::vector<int> nessential, Vec rho0){
+int OptimTarget::prepareInitialState(const int iinit, const int ninit, const std::vector<int>& nlevels, const std::vector<int>& nessential, Vec rho0){
 
   PetscInt ilow, iupp; 
   PetscInt elemID;

--- a/src/oscillator.cpp
+++ b/src/oscillator.cpp
@@ -7,7 +7,7 @@ Oscillator::Oscillator(){
   control_enforceBC = true;
 }
 
-Oscillator::Oscillator(Config config, size_t id, std::vector<int> nlevels_all_, std::vector<std::string>& controlsegments, std::vector<std::string>& controlinitializations, double ground_freq_, double selfkerr_, double rotational_freq_, double decay_time_, double dephase_time_, std::vector<double> carrier_freq_, double Tfinal_, LindbladType lindbladtype_, std::default_random_engine rand_engine){
+Oscillator::Oscillator(Config config, size_t id, const std::vector<int>& nlevels_all_, std::vector<std::string>& controlsegments, std::vector<std::string>& controlinitializations, double ground_freq_, double selfkerr_, double rotational_freq_, double decay_time_, double dephase_time_, const std::vector<double>& carrier_freq_, double Tfinal_, LindbladType lindbladtype_, std::default_random_engine rand_engine){
 
   myid = id;
   nlevels = nlevels_all_[id];


### PR DESCRIPTION
Use const references for vectors/strings in function signatures to avoid unneccessary copies. These vectors/strings are likely very small so I don't think this will make any noticeable difference in performance. But stylistically I think it is nice because it makes it clear from the signature that you don't alter those.

