### PR TITLE
Fix a permission issue in GitHub workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,4 +65,4 @@ jobs:
         else
           spack -e .spack_env buildcache push --update-index local-buildcache
         fi
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}


### PR DESCRIPTION
Fix a permission issue that may cause GitHub workflows to fail by only pushing to GHCR from this repo, not from forks