### PR TITLE
Add --version to binary and release 4.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(
     VERSION 4.1
     LANGUAGES CXX C
 )
+set(PROJECT_VERSION_SUFFIX "")
+set(FULL_VERSION "${PROJECT_VERSION}${PROJECT_VERSION_SUFFIX}")
 
 option(BUILD_QUANDARY "Build Quandary targets" ON)
 
@@ -42,6 +44,13 @@ if (NOT BLT_LOADED)
   message(STATUS "BLT Source Directory: ${BLT_SOURCE_DIR}")
   include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
 endif()
+
+# Configure version header
+configure_file(
+    ${CMAKE_SOURCE_DIR}/include/version.hpp.in
+    ${CMAKE_BINARY_DIR}/include/version.hpp
+    @ONLY
+)
 
 if(BUILD_QUANDARY)
   add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 3.23)
 
 project(
     Quandary
-    VERSION 4.2
+    VERSION 4.3
     LANGUAGES CXX C
 )
-set(PROJECT_VERSION_SUFFIX "")
+set(PROJECT_VERSION_SUFFIX "-dev")
 set(FULL_VERSION "${PROJECT_VERSION}${PROJECT_VERSION_SUFFIX}")
 
 option(BUILD_QUANDARY "Build Quandary targets" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.23)
 
 project(
     Quandary
-    VERSION 4.1
+    VERSION 4.2
     LANGUAGES CXX C
 )
 set(PROJECT_VERSION_SUFFIX "")

--- a/include/version.hpp.in
+++ b/include/version.hpp.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#define QUANDARY_FULL_VERSION_STRING "@FULL_VERSION@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quandary"
-version = "4.1"
+version = "4.2"
 description = "Optimal control for open quantum systems"
 authors = [
     {name = "Stefanie Guenther",email = "guenther5@llnl.gov"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quandary"
-version = "4.2"
+version = "4.3-dev"
 description = "Optimal control for open quantum systems"
 authors = [
     {name = "Stefanie Guenther",email = "guenther5@llnl.gov"}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ blt_add_library(
     NAME quandary_lib
     SOURCES ${SRC_FILES}
     HEADERS ${HEADER_FILES}
-    INCLUDES ${INC_DIR}
+    INCLUDES ${INC_DIR} ${CMAKE_BINARY_DIR}/include
     DEPENDS_ON blt::mpi
 )
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include "output.hpp"
 #include "petsc.h"
 #include <random>
+#include "version.hpp"
 #ifdef WITH_SLEPC
 #include <slepceps.h>
 #endif
@@ -31,7 +32,14 @@ int main(int argc,char **argv)
   MPI_Comm_rank(MPI_COMM_WORLD, &mpirank_world);
   MPI_Comm_size(MPI_COMM_WORLD, &mpisize_world);
 
-  /* Parse argument line for "--quiet" to enable reduced output mode */
+  if (argc > 1 && std::string(argv[1]) == "--version") {
+    if (mpirank_world == 0) {
+      printf("Quandary %s\n", QUANDARY_FULL_VERSION_STRING);
+    }
+    MPI_Finalize();
+    return 0;
+  }
+
   bool quietmode = false;
   if (argc > 2){
     for (int i=2; i<argc; i++) {
@@ -48,7 +56,18 @@ int main(int argc,char **argv)
   /* Read config file */
   if (argc < 2) {
     if (mpirank_world == 0) {
-      printf("\nUSAGE: ./main </path/to/configfile> \n");
+      printf("\nQuandary - Optimal control for open quantum systems\n");
+      printf("\nUSAGE:\n");
+      printf("  quandary <config_file> [--quiet]\n");
+      printf("  quandary --version\n");
+      printf("\nOPTIONS:\n");
+      printf("  <config_file>    Configuration file (.cfg) specifying system parameters\n");
+      printf("  --quiet          Reduce output verbosity\n");
+      printf("  --version        Show version information\n");
+      printf("\nEXAMPLES:\n");
+      printf("  quandary config.cfg\n");
+      printf("  mpirun -np 4 quandary config.cfg --quiet\n");
+      printf("\n");
     }
     MPI_Finalize();
     return 0;


### PR DESCRIPTION
- Add command `quandary --version` that prints out the version specified in CMakeLists.txt.
- Update the help that gets printed out when you do `./quandary`.
- Update the version to 4.2 (tag this commit as release)
- Update the version to 4.3-dev (this is the version that the code will have after the 4.2 release, since we are developing towards 4.3).