### PR TITLE
Switch colocated state storage to blocked storage

### DIFF
--- a/docs/mkdocs/user_guide.md
+++ b/docs/mkdocs/user_guide.md
@@ -302,22 +302,8 @@ to derive the vectorized master equation for $q(t) := \text{vec}(\rho(t)) \in \C
 \end{align}
 
 
-The real and imaginary parts of $q(t)$ are stored in a colocated manner: For
-  $q = u+iv$ with $u,v\in\R^{M}$, a vector of size $2M$ is stored that
-  staggers real and imaginary parts behind each other for each component:
-
-\begin{align*}
-  q = u+iv = \begin{bmatrix}
-    u^1\\u^2\\ \vdots \\ u^{M}
-  \end{bmatrix}
-  + i \begin{bmatrix}
-    v^1\\v^2\\ \vdots \\ v^{M}
-  \end{bmatrix}
-  \quad \Rightarrow \quad
-  q_{store} = \begin{bmatrix}
-    u_1 \\ v_1\\ u_2 \\ v_2 \\ \vdots \\ u_{M} \\ v_{M}
-  \end{bmatrix}
-\end{align*}
+The real and imaginary parts of $q(t)$ are stored in blocked manner: For
+  $q = u+iv$ with $u,v\in\R^{M}$, a vector of size $2M$ as $q=\begin{bmatrix} u\\v \end{bmatrix}.
 
 ## Time-stepping
 To solve the resulting real-valued differential equation 
@@ -450,7 +436,7 @@ It is currently required that the number of total cores for executing quandary i
 
 It is further required that the system dimension is an integer multiple of the number of cores used for distributed linear algebra from Petsc, i.e. it is required that $\frac{M}{np_{petsc}} \in \mathbb{N}$ where $M=N^2$ in the Lindblad solver case and $M=N$ in the Schroedinger case. This requirement is a little
   annoying, however the current implementation requires this due to the
-  colocated storage of the real and imaginary parts of the vectorized
+  storage of the real and imaginary parts of the vectorized
   state.
 
 # Output and plotting the results

--- a/include/gate.hpp
+++ b/include/gate.hpp
@@ -22,6 +22,7 @@ class Gate {
     std::vector<int> nessential; ///< Number of essential levels per oscillator.
     std::vector<int> nlevels; ///< Total number of levels per oscillator.
     int mpirank_petsc; ///< MPI rank in PETSc communicator.
+    int mpisize_petsc; ///< MPI size in PETSc communicator.
     int mpirank_world; ///< MPI rank in world communicator.
 
     bool quietmode; ///< Flag to suppress output messages.

--- a/include/mastereq.hpp
+++ b/include/mastereq.hpp
@@ -111,9 +111,13 @@ class MasterEq{
     std::vector<double> eta; ///< Frequency differences in rotating frame (rad/time) for dipole-dipole coupling
     bool addT1, addT2; ///< Flags for including T1 decay and T2 dephasing Lindblad operators
 
-    int mpirank_petsc; ///< Rank of PETSc's communicator
-    int mpisize_petsc;
     int mpirank_world; ///< Rank of global MPI communicator
+    int mpirank_petsc; ///< Rank of PETSc's communicator
+    int mpisize_petsc; ///< Size of PETSc's communicator
+    PetscInt localsize_u; ///< Size of local sub vector u or v in state x=[u,v]
+    PetscInt ilow; ///< First index of the local sub vector u,v
+    PetscInt iupp; ///< Last index (+1) of the local sub vector u,v
+
     IS isu, isv; ///< Vector strides for accessing real and imaginary parts u=Re(x), v=Im(x)
     Vec aux; ///< Auxiliary vector for computations
     bool quietmode; ///< Flag for quiet mode operation

--- a/include/mastereq.hpp
+++ b/include/mastereq.hpp
@@ -619,15 +619,13 @@ inline void dRHSdp_getcoeffs(const PetscInt dim, const int it, const int n, cons
  * @param yre Pointer to store real part of result
  * @param yim Pointer to store imaginary part of result
  */
-inline void Jkl_coupling(const int it, const int ni, const int nj, const int nip, const int njp, const int i, const int ip, const int j, const int jp, const int stridei, const int strideip, const int stridej, const int stridejp, const double* xptr, const double Jij, const double cosij, const double sinij, double* yre, double* yim) {
-  printf("TODO Jkl coupling with blocked vectors\n");
-  exit(1);
+inline void Jkl_coupling(const PetscInt dim, const int it, const int ni, const int nj, const int nip, const int njp, const int i, const int ip, const int j, const int jp, const int stridei, const int strideip, const int stridej, const int stridejp, const double* xptr, const double Jij, const double cosij, const double sinij, double* yre, double* yim) {
   if (fabs(Jij)>1e-10) {
     //  1) J_kl (-icos + sin) * ρ_{E−k+l i, i′}
     if (i > 0 && j < nj-1) {
       int itx = it - stridei + stridej;
-      double xre = xptr[2 * itx];
-      double xim = xptr[2 * itx + 1];
+      double xre = xptr[getIndexReal(itx)];
+      double xim = xptr[getIndexImag(itx, dim)];
       double sq = sqrt(i * (j + 1));
       // sin u + cos v + i ( -cos u + sin v)
       *yre += Jij * sq * (   cosij * xim + sinij * xre);
@@ -636,8 +634,8 @@ inline void Jkl_coupling(const int it, const int ni, const int nj, const int nip
     // 2) J_kl (−icos − sin)sqrt(il*(ik +1)) ρ_{E+k−li,i′}
     if (i < ni-1 && j > 0) {
       int itx = it + stridei - stridej;  // E+k-l i, i'
-      double xre = xptr[2 * itx];
-      double xim = xptr[2 * itx + 1];
+      double xre = xptr[getIndexReal(itx)];
+      double xim = xptr[getIndexImag(itx, dim)];
       double sq = sqrt(j * (i + 1)); // sqrt( il*(ik+1))
       // -sin u + cos v + i (-cos u - sin v)
       *yre += Jij * sq * (   cosij * xim - sinij * xre);
@@ -646,8 +644,8 @@ inline void Jkl_coupling(const int it, const int ni, const int nj, const int nip
     // 3) J_kl ( icos + sin)sqrt(ik'*(il' +1)) ρ_{i,E-k+li'}
     if (ip > 0 && jp < njp-1) {
       int itx = it - strideip + stridejp;  // i, E-k+l i'
-      double xre = xptr[2 * itx];
-      double xim = xptr[2 * itx + 1];
+      double xre = xptr[getIndexReal(itx)];
+      double xim = xptr[getIndexImag(itx, dim)];
       double sq = sqrt(ip * (jp + 1)); // sqrt( ik'*(il'+1))
       //  sin u - cos v + i ( cos u + sin v)
       *yre += Jij * sq * ( - cosij * xim + sinij * xre);
@@ -656,8 +654,8 @@ inline void Jkl_coupling(const int it, const int ni, const int nj, const int nip
     // 4) J_kl ( icos - sin)sqrt(il'*(ik' +1)) ρ_{i,E+k-li'}
     if (ip < nip-1 && jp > 0) {
       int itx = it + strideip - stridejp;  // i, E+k-l i'
-      double xre = xptr[2 * itx];
-      double xim = xptr[2 * itx + 1];
+      double xre = xptr[getIndexReal(itx)];
+      double xim = xptr[getIndexImag(itx, dim)];
       double sq = sqrt(jp * (ip + 1)); // sqrt( il'*(ik'+1))
       // - sin u - cos v + i ( cos u - sin v)
       *yre += Jij * sq * ( - cosij * xim - sinij * xre);
@@ -689,13 +687,13 @@ inline void Jkl_coupling(const int it, const int ni, const int nj, const int nip
  * @param yre Pointer to store real part of result
  * @param yim Pointer to store imaginary part of result
  */
-inline void Jkl_coupling_T(const int it, const int ni, const int nj, const int nip, const int njp, const int i, const int ip, const int j, const int jp, const int stridei, const int strideip, const int stridej, const int stridejp, const double* xptr, const double Jij, const double cosij, const double sinij, double* yre, double* yim) {
+inline void Jkl_coupling_T(const PetscInt dim, const int it, const int ni, const int nj, const int nip, const int njp, const int i, const int ip, const int j, const int jp, const int stridei, const int strideip, const int stridej, const int stridejp, const double* xptr, const double Jij, const double cosij, const double sinij, double* yre, double* yim) {
   if (fabs(Jij)>1e-10) {
     //  1) [...] * \bar y_{E+k-l i, i′}
     if (i < ni-1 && j > 0) {
       int itx = it + stridei - stridej;
-      double xre = xptr[2 * itx];
-      double xim = xptr[2 * itx + 1];
+      double xre = xptr[getIndexReal(itx)];
+      double xim = xptr[getIndexImag(itx, dim)];
       double sq = sqrt(j * (i + 1));
       *yre += Jij * sq * ( - cosij * xim + sinij * xre);
       *yim += Jij * sq * ( + cosij * xre + sinij * xim);
@@ -703,8 +701,8 @@ inline void Jkl_coupling_T(const int it, const int ni, const int nj, const int n
     // 2) J_kl (−icos − sin)sqrt(ik*(il +1)) \bar y_{E-k+li,i′}
     if (i > 0 && j < nj-1) {
       int itx = it - stridei + stridej;  // E-k+l i, i'
-      double xre = xptr[2 * itx];
-      double xim = xptr[2 * itx + 1];
+      double xre = xptr[getIndexReal(itx)];
+      double xim = xptr[getIndexImag(itx, dim)];
       double sq = sqrt(i * (j + 1)); // sqrt( ik*(il+1))
       *yre += Jij * sq * ( - cosij * xim - sinij * xre);
       *yim += Jij * sq * ( + cosij * xre - sinij * xim);
@@ -712,8 +710,8 @@ inline void Jkl_coupling_T(const int it, const int ni, const int nj, const int n
     // 3) J_kl ( icos + sin)sqrt(il'*(ik' +1)) \bar y_{i,E+k-li'}
     if (ip < nip-1 && jp > 0) {
       int itx = it + strideip - stridejp;  // i, E+k-l i'
-      double xre = xptr[2 * itx];
-      double xim = xptr[2 * itx + 1];
+      double xre = xptr[getIndexReal(itx)];
+      double xim = xptr[getIndexImag(itx, dim)];
       double sq = sqrt(jp * (ip + 1)); // sqrt( il'*(ik'+1))
       *yre += Jij * sq * (   cosij * xim + sinij * xre);
       *yim += Jij * sq * ( - cosij * xre + sinij * xim);
@@ -721,8 +719,8 @@ inline void Jkl_coupling_T(const int it, const int ni, const int nj, const int n
     // 4) J_kl ( icos - sin)sqrt(ik'*(il' +1)) \bar y_{i,E-k+li'}
     if (ip > 0 && jp < njp-1) {
       int itx = it - strideip + stridejp;  // i, E-k+l i'
-      double xre = xptr[2 * itx];
-      double xim = xptr[2 * itx + 1];
+      double xre = xptr[getIndexReal(itx)];
+      double xim = xptr[getIndexImag(itx, dim)];
       double sq = sqrt(ip * (jp + 1)); // sqrt( ik'*(il'+1))
       *yre += Jij * sq * (   cosij * xim - sinij * xre);
       *yim += Jij * sq * ( - cosij * xre - sinij * xim);

--- a/include/optimproblem.hpp
+++ b/include/optimproblem.hpp
@@ -58,7 +58,7 @@ class OptimProblem {
   MPI_Comm comm_init; ///< MPI communicator for initial condition parallelization
   MPI_Comm comm_optim; ///< MPI communicator for optimization parallelization, currently not used (size 1)
   int mpirank_optim, mpisize_optim; ///< MPI rank and size for optimization communicator
-  int mpirank_space, mpisize_space; ///< MPI rank and size for spatial parallelization (PETSc)
+  int mpirank_petsc, mpisize_petsc; ///< MPI rank and size for spatial parallelization (PETSc)
   int mpirank_world, mpisize_world; ///< MPI rank and size for global communicator
   int mpirank_init, mpisize_init; ///< MPI rank and size for initial condition communicator
 

--- a/include/optimtarget.hpp
+++ b/include/optimtarget.hpp
@@ -39,9 +39,9 @@ class OptimTarget{
     LindbladType lindbladtype; ///< Type of Lindblad decoherence operators, or NONE for Schroedinger solver
     int mpisize_petsc; ///< Size of PETSc communicator
     int mpirank_petsc; ///< Rank of PETSc communicator
-    PetscInt ilow; 
-    PetscInt iupp; 
-    PetscInt localsize_u;
+    PetscInt localsize_u; ///< Size of local sub vector u or v in state x=[u,v]
+    PetscInt ilow; ///< First index of the local sub vector u,v
+    PetscInt iupp; ///< Last index (+1) of the local sub vector u,v
 
     Vec aux; ///< Auxiliary vector for gate optimization objective computation
     bool quietmode; ///< Flag for quiet mode operation

--- a/include/optimtarget.hpp
+++ b/include/optimtarget.hpp
@@ -37,6 +37,11 @@ class OptimTarget{
     InitialConditionType initcond_type; ///< Type of initial conditions
     std::vector<size_t> initcond_IDs; ///< Integer list for pure-state initialization
     LindbladType lindbladtype; ///< Type of Lindblad decoherence operators, or NONE for Schroedinger solver
+    int mpisize_petsc; ///< Size of PETSc communicator
+    int mpirank_petsc; ///< Rank of PETSc communicator
+    PetscInt ilow; 
+    PetscInt iupp; 
+    PetscInt localsize_u;
 
     Vec aux; ///< Auxiliary vector for gate optimization objective computation
     bool quietmode; ///< Flag for quiet mode operation

--- a/include/oscillator.hpp
+++ b/include/oscillator.hpp
@@ -63,6 +63,7 @@ class Oscillator {
     std::vector<double> carrier_freq; ///< Frequencies of the carrier waves
 
     int mpirank_petsc; ///< Rank of PETSc's communicator
+    int mpisize_petsc; ///< Size of PETSc's communicator
     int mpirank_world; ///< Rank of MPI_COMM_WORLD
 
     bool control_enforceBC; ///< Flag to enforce boundary conditions on controls

--- a/include/oscillator.hpp
+++ b/include/oscillator.hpp
@@ -62,9 +62,12 @@ class Oscillator {
     std::vector<ControlBasis *> basisfunctions; ///< Control parameterization basis functions for each time segment
     std::vector<double> carrier_freq; ///< Frequencies of the carrier waves
 
+    int mpirank_world; ///< Rank of MPI_COMM_WORLD
     int mpirank_petsc; ///< Rank of PETSc's communicator
     int mpisize_petsc; ///< Size of PETSc's communicator
-    int mpirank_world; ///< Rank of MPI_COMM_WORLD
+    PetscInt localsize_u; ///< Size of local sub vector u or v in state x=[u,v]
+    PetscInt ilow; ///< First index of the local sub vector u,v
+    PetscInt iupp; ///< Last index (+1) of the local sub vector u,v
 
     bool control_enforceBC; ///< Flag to enforce boundary conditions on controls
 

--- a/include/timestepper.hpp
+++ b/include/timestepper.hpp
@@ -32,7 +32,6 @@
  */
 class TimeStepper{
   protected:
-    PetscInt dim; ///< State vector dimension
     Vec x; ///< Auxiliary vector for forward time stepping
     Vec xadj; ///< Auxiliary vector needed for adjoint (backward) time stepping
     Vec xprimal; ///< Auxiliary vector for backward time stepping

--- a/include/timestepper.hpp
+++ b/include/timestepper.hpp
@@ -41,6 +41,9 @@ class TimeStepper{
     int mpirank_world; ///< MPI rank in global communicator
     int mpisize_petsc; ///< MPI size in Petsc communicator
     int mpirank_petsc; ///< MPI rank in Petsc communicator
+    PetscInt localsize_u; ///< Size of local sub vector u or v in state x=[u,v]
+    PetscInt ilow; ///< First index of the local sub vector u,v
+    PetscInt iupp; ///< Last index (+1) of the local sub vector u,v
 
   public:
     MasterEq* mastereq; ///< Pointer to master equation solver

--- a/include/timestepper.hpp
+++ b/include/timestepper.hpp
@@ -40,6 +40,8 @@ class TimeStepper{
     std::vector<Vec> dpdm_states; ///< Storage for states needed for second-order derivative penalty
     bool addLeakagePrevent; ///< Flag to include leakage prevention penalty term
     int mpirank_world; ///< MPI rank in global communicator
+    int mpisize_petsc; ///< MPI size in Petsc communicator
+    int mpirank_petsc; ///< MPI rank in Petsc communicator
 
   public:
     MasterEq* mastereq; ///< Pointer to master equation solver

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -52,23 +52,6 @@ double getRampFactor(const double time, const double tstart, const double tstop,
 double getRampFactor_diff(const double time, const double tstart, const double tstop, const double tramp);
 
 /**
- * @brief Returns storage index for real part of a state vector element.
- *
- * @param i Element index
- * @return int Storage index (blocked: x[i])
- */
-PetscInt getIndexReal(const PetscInt i);
-
-/**
- * @brief Returns storage index for imaginary part of a state vector element.
- *
- * @param i Element index
- * @param size Size of real-valued subvector
- * @return int Storage index (blocked: x[i+size])
- */
-PetscInt getIndexImag(const PetscInt i, const PetscInt size);
-
-/**
  * @brief Returns vectorized index for matrix element (row,col).
  *
  * @param row Matrix row index

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -55,7 +55,7 @@ double getRampFactor_diff(const double time, const double tstart, const double t
  * @brief Returns storage index for real part of a state vector element.
  *
  * @param i Element index
- * @return int Storage index (colocated: x[2*i])
+ * @return int Storage index (blocked: x[i])
  */
 PetscInt getIndexReal(const PetscInt i);
 
@@ -63,9 +63,10 @@ PetscInt getIndexReal(const PetscInt i);
  * @brief Returns storage index for imaginary part of a state vector element.
  *
  * @param i Element index
- * @return int Storage index (colocated: x[2*i+1])
+ * @param size Size of real-valued subvector
+ * @return int Storage index (blocked: x[i+size])
  */
-PetscInt getIndexImag(const PetscInt i);
+PetscInt getIndexImag(const PetscInt i, const PetscInt size);
 
 /**
  * @brief Returns vectorized index for matrix element (row,col).

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -68,10 +68,12 @@ Gate::Gate(const std::vector<int>& nlevels_, const std::vector<int>& nessential_
   /* Create vector strides for accessing real and imaginary part of co-located state */
   PetscInt ilow, iupp;
   MatGetOwnershipRange(VxV_re, &ilow, &iupp);
+  // PetscInt dimis = iupp - ilow;
+  // ISCreateStride(PETSC_COMM_WORLD, dimis, 2*ilow, 2, &isu);
+  // ISCreateStride(PETSC_COMM_WORLD, dimis, 2*ilow+1, 2, &isv);
   PetscInt dimis = iupp - ilow;
-  ISCreateStride(PETSC_COMM_WORLD, dimis, 2*ilow, 2, &isu);
-  ISCreateStride(PETSC_COMM_WORLD, dimis, 2*ilow+1, 2, &isv);
- 
+  ISCreateStride(PETSC_COMM_WORLD, dimis, ilow, 1, &isu);
+  ISCreateStride(PETSC_COMM_WORLD, dimis, ilow+dim_gate, 1, &isv);
 }
 
 Gate::~Gate(){

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -68,11 +68,10 @@ Gate::Gate(const std::vector<int>& nlevels_, const std::vector<int>& nessential_
   MatCreateVecs(VxV_re, &x, NULL);
 
 
-  /* Create vector strides for accessing real and imaginary part of co-located state */
-  PetscInt localsize_x = 2 * localsize_u;       // local size of global state vector x=[u,v]
-  PetscInt ilow = mpirank_petsc * localsize_x;  // local index of first element in global x=[u,v];
-  ISCreateStride(PETSC_COMM_WORLD, localsize_u, ilow, 1, &isu);             // access local u
-  ISCreateStride(PETSC_COMM_WORLD, localsize_u, ilow+localsize_u, 1, &isv); // access local v
+  /* Create vector strides for accessing u,v in state x=[u,v] */
+  PetscInt ilow = mpirank_petsc * localsize_u;  
+  ISCreateStride(PETSC_COMM_WORLD, localsize_u, ilow*2, 1, &isu); 
+  ISCreateStride(PETSC_COMM_WORLD, localsize_u, ilow*2+localsize_u, 1, &isv); 
 }
 
 Gate::~Gate(){

--- a/src/mastereq.cpp
+++ b/src/mastereq.cpp
@@ -284,7 +284,6 @@ void MasterEq::initSparseMatSolver(){
   /* Else: Initialize system matrices with standard Hamiltonian model */
   } else {
 
-    PetscInt ilow, iupp;
     PetscInt r1,r2, r1a, r2a, r1b, r2b;
     PetscInt col, col1, col2;
     double val;
@@ -298,7 +297,6 @@ void MasterEq::initSparseMatSolver(){
       /* Set control Hamiltonian system matrix real(-iHc) */
       /* Lindblad solver:     Ac = I_N \kron (a - a^T) - (a - a^T)^T \kron I_N   \in C^{N^2 x N^2}*/
       /* Schroedinger solver: Ac = a - a^T   \in C^{N x N}  */
-      MatGetOwnershipRange(Ac_vec[iosc], &ilow, &iupp);
       for (PetscInt row = ilow; row<iupp; row++){
         // A_c or I_N \kron A_c
         col1 = row + npostk;
@@ -336,7 +334,6 @@ void MasterEq::initSparseMatSolver(){
       /* Lindblas solver Bc = - I_N \kron (a + a^T) + (a + a^T)^T \kron I_N */
       /* Schroedinger solver: Bc = -(a+a^T) */
       /* Iterate over local rows of Bc_vec */
-      MatGetOwnershipRange(Bc_vec[iosc], &ilow, &iupp);
       for (int row = ilow; row<iupp; row++){
         // B_c or  I_n \kron B_c 
         col1 = row + npostk;
@@ -393,7 +390,6 @@ void MasterEq::initSparseMatSolver(){
           PetscInt npostj = oscil_vec[josc]->dim_postOsc;
 
           /* Iterate over local rows of Ad_vec / Bd_vec */
-          MatGetOwnershipRange(Ad_vec[matid], &ilow, &iupp);
           for (PetscInt row = ilow; row<iupp; row++){
             // Add +/- I_N \kron (ak^Tal -/+ akal^T) (Lindblad)
             // or  +/- (ak^Tal -/+ akal^T) (Schrodinger)
@@ -453,7 +449,6 @@ void MasterEq::initSparseMatSolver(){
 
       /* Diagonal: detuning and anharmonicity  */
       /* Iterate over local rows of Bd */
-      MatGetOwnershipRange(Bd, &ilow, &iupp);
       for (PetscInt row = ilow; row<iupp; row++){
 
         // Indices for -I_N \kron B_d
@@ -550,7 +545,6 @@ void MasterEq::initSparseMatSolver(){
   /* Set Ad = Lindblad terms */
   if (addT1 || addT2) {  // leave matrix empty if no T1 or T2 decay
 
-    PetscInt ilow, iupp;
     PetscInt r1,r1a, r1b;
     PetscInt col1;
     double val;
@@ -567,7 +561,6 @@ void MasterEq::initSparseMatSolver(){
       PetscInt npostk = oscil_vec[iosc]->dim_postOsc;
 
       /* Iterate over local rows of Ad */
-      MatGetOwnershipRange(Ad, &ilow, &iupp);
       for (PetscInt row = ilow; row<iupp; row++){
 
         /* Add Ad += gamma_j * L \kron L */

--- a/src/mastereq.cpp
+++ b/src/mastereq.cpp
@@ -1556,7 +1556,7 @@ int applyRHS_matfree(Mat RHS, Vec x, Vec y){
 
           /* --- Offdiagonal: Jkl coupling term --- */
           // oscillator 0<->1 
-          Jkl_coupling(it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
+          Jkl_coupling(shellctx->dim, it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
 
           /* --- Offdiagonal part of decay L1 */
           if (shellctx->lindbladtype != LindbladType::NONE) {
@@ -1680,7 +1680,7 @@ int applyRHS_matfree_transpose(Mat RHS, Vec x, Vec y){
 
           /* --- Offdiagonal coupling term J_kl --- */
           // oscillator 0<->1
-          Jkl_coupling_T(it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
+          Jkl_coupling_T(shellctx->dim, it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
  
           /* --- Offdiagonal part of decay L1^T */
           if (shellctx->lindbladtype != LindbladType::NONE) {
@@ -1823,11 +1823,11 @@ int applyRHS_matfree(Mat RHS, Vec x, Vec y){
 
               /* --- Offdiagonal: Jkl coupling  --- */
               // oscillator 0<->1 
-              Jkl_coupling(it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
+              Jkl_coupling(shellctx->dim, it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
               // oscillator 0<->2
-              Jkl_coupling(it, n0, n2, n0p, n2p, i0, i0p, i2, i2p, stridei0, stridei0p, stridei2, stridei2p, xptr, J02, cos02, sin02, &yre, &yim);
+              Jkl_coupling(shellctx->dim, it, n0, n2, n0p, n2p, i0, i0p, i2, i2p, stridei0, stridei0p, stridei2, stridei2p, xptr, J02, cos02, sin02, &yre, &yim);
               // oscillator 1<->2
-              Jkl_coupling(it, n1, n2, n1p, n2p, i1, i1p, i2, i2p, stridei1, stridei1p, stridei2, stridei2p, xptr, J12, cos12, sin12, &yre, &yim);
+              Jkl_coupling(shellctx->dim, it, n1, n2, n1p, n2p, i1, i1p, i2, i2p, stridei1, stridei1p, stridei2, stridei2p, xptr, J12, cos12, sin12, &yre, &yim);
 
               /* --- Offdiagonal part of decay L1 */
               if (shellctx->lindbladtype != LindbladType::NONE) {
@@ -1977,11 +1977,11 @@ int applyRHS_matfree_transpose(Mat RHS, Vec x, Vec y){
 
               /* --- Offdiagonal coupling term J_kl --- */
               // oscillator 0<->1
-              Jkl_coupling_T(it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
+              Jkl_coupling_T(shellctx->dim, it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
               // oscillator 0<->2
-              Jkl_coupling_T(it, n0, n2, n0p, n2p, i0, i0p, i2, i2p, stridei0, stridei0p, stridei2, stridei2p, xptr, J02, cos02, sin02, &yre, &yim);
+              Jkl_coupling_T(shellctx->dim, it, n0, n2, n0p, n2p, i0, i0p, i2, i2p, stridei0, stridei0p, stridei2, stridei2p, xptr, J02, cos02, sin02, &yre, &yim);
               // oscillator 1<->2
-              Jkl_coupling_T(it, n1, n2, n1p, n2p, i1, i1p, i2, i2p, stridei1, stridei1p, stridei2, stridei2p, xptr, J12, cos12, sin12, &yre, &yim);
+              Jkl_coupling_T(shellctx->dim, it, n1, n2, n1p, n2p, i1, i1p, i2, i2p, stridei1, stridei1p, stridei2, stridei2p, xptr, J12, cos12, sin12, &yre, &yim);
               
 
               /* --- Offdiagonal part of decay L1^T */
@@ -2161,17 +2161,17 @@ int applyRHS_matfree(Mat RHS, Vec x, Vec y){
 
                   /* --- Offdiagonal: Jkl coupling  --- */
                   // oscillator 0<->1 
-                  Jkl_coupling(it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
+                  Jkl_coupling(shellctx->dim, it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
                   // oscillator 0<->2
-                  Jkl_coupling(it, n0, n2, n0p, n2p, i0, i0p, i2, i2p, stridei0, stridei0p, stridei2, stridei2p, xptr, J02, cos02, sin02, &yre, &yim);
+                  Jkl_coupling(shellctx->dim, it, n0, n2, n0p, n2p, i0, i0p, i2, i2p, stridei0, stridei0p, stridei2, stridei2p, xptr, J02, cos02, sin02, &yre, &yim);
                   // oscillator 0<->3
-                  Jkl_coupling(it, n0, n3, n0p, n3p, i0, i0p, i3, i3p, stridei0, stridei0p, stridei3, stridei3p, xptr, J03, cos03, sin03, &yre, &yim);
+                  Jkl_coupling(shellctx->dim, it, n0, n3, n0p, n3p, i0, i0p, i3, i3p, stridei0, stridei0p, stridei3, stridei3p, xptr, J03, cos03, sin03, &yre, &yim);
                   // oscillator 1<->2
-                  Jkl_coupling(it, n1, n2, n1p, n2p, i1, i1p, i2, i2p, stridei1, stridei1p, stridei2, stridei2p, xptr, J12, cos12, sin12, &yre, &yim);
+                  Jkl_coupling(shellctx->dim, it, n1, n2, n1p, n2p, i1, i1p, i2, i2p, stridei1, stridei1p, stridei2, stridei2p, xptr, J12, cos12, sin12, &yre, &yim);
                   // oscillator 1<->3
-                  Jkl_coupling(it, n1, n3, n1p, n3p, i1, i1p, i3, i3p, stridei1, stridei1p, stridei3, stridei3p, xptr, J13, cos13, sin13, &yre, &yim);
+                  Jkl_coupling(shellctx->dim, it, n1, n3, n1p, n3p, i1, i1p, i3, i3p, stridei1, stridei1p, stridei3, stridei3p, xptr, J13, cos13, sin13, &yre, &yim);
                   // oscillator 2<->3
-                  Jkl_coupling(it, n2, n3, n2p, n3p, i2, i2p, i3, i3p, stridei2, stridei2p, stridei3, stridei3p, xptr, J23, cos23, sin23, &yre, &yim);
+                  Jkl_coupling(shellctx->dim, it, n2, n3, n2p, n3p, i2, i2p, i3, i3p, stridei2, stridei2p, stridei3, stridei3p, xptr, J23, cos23, sin23, &yre, &yim);
 
                   /* --- Offdiagonal part of decay L1 */
                   if (shellctx->lindbladtype != LindbladType::NONE) {
@@ -2356,17 +2356,17 @@ int applyRHS_matfree_transpose(Mat RHS, Vec x, Vec y){
 
                   /* --- Offdiagonal coupling term J_kl --- */
                   // oscillator 0<->1
-                  Jkl_coupling_T(it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
+                  Jkl_coupling_T(shellctx->dim, it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
                   // oscillator 0<->2
-                  Jkl_coupling_T(it, n0, n2, n0p, n2p, i0, i0p, i2, i2p, stridei0, stridei0p, stridei2, stridei2p, xptr, J02, cos02, sin02, &yre, &yim);
+                  Jkl_coupling_T(shellctx->dim, it, n0, n2, n0p, n2p, i0, i0p, i2, i2p, stridei0, stridei0p, stridei2, stridei2p, xptr, J02, cos02, sin02, &yre, &yim);
                   // oscillator 0<->3
-                  Jkl_coupling_T(it, n0, n3, n0p, n3p, i0, i0p, i3, i3p, stridei0, stridei0p, stridei3, stridei3p, xptr, J03, cos03, sin03, &yre, &yim);
+                  Jkl_coupling_T(shellctx->dim, it, n0, n3, n0p, n3p, i0, i0p, i3, i3p, stridei0, stridei0p, stridei3, stridei3p, xptr, J03, cos03, sin03, &yre, &yim);
                   // oscillator 1<->2
-                  Jkl_coupling_T(it, n1, n2, n1p, n2p, i1, i1p, i2, i2p, stridei1, stridei1p, stridei2, stridei2p, xptr, J12, cos12, sin12, &yre, &yim);
+                  Jkl_coupling_T(shellctx->dim, it, n1, n2, n1p, n2p, i1, i1p, i2, i2p, stridei1, stridei1p, stridei2, stridei2p, xptr, J12, cos12, sin12, &yre, &yim);
                   // oscillator 1<->3
-                  Jkl_coupling_T(it, n1, n3, n1p, n3p, i1, i1p, i3, i3p, stridei1, stridei1p, stridei3, stridei3p, xptr, J13, cos13, sin13, &yre, &yim);
+                  Jkl_coupling_T(shellctx->dim, it, n1, n3, n1p, n3p, i1, i1p, i3, i3p, stridei1, stridei1p, stridei3, stridei3p, xptr, J13, cos13, sin13, &yre, &yim);
                   // oscillator 2<->3
-                  Jkl_coupling_T(it, n2, n3, n2p, n3p, i2, i2p, i3, i3p, stridei2, stridei2p, stridei3, stridei3p, xptr, J23, cos23, sin23, &yre, &yim);
+                  Jkl_coupling_T(shellctx->dim, it, n2, n3, n2p, n3p, i2, i2p, i3, i3p, stridei2, stridei2p, stridei3, stridei3p, xptr, J23, cos23, sin23, &yre, &yim);
               
 
                   /* --- Offdiagonal part of decay L1^T */
@@ -2585,25 +2585,25 @@ int applyRHS_matfree(Mat RHS, Vec x, Vec y){
 
                       /* --- Offdiagonal: Jkl coupling  --- */
                       // oscillator 0<->1 
-                      Jkl_coupling(it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
+                      Jkl_coupling(shellctx->dim, it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
                       // oscillator 0<->2
-                      Jkl_coupling(it, n0, n2, n0p, n2p, i0, i0p, i2, i2p, stridei0, stridei0p, stridei2, stridei2p, xptr, J02, cos02, sin02, &yre, &yim);
+                      Jkl_coupling(shellctx->dim, it, n0, n2, n0p, n2p, i0, i0p, i2, i2p, stridei0, stridei0p, stridei2, stridei2p, xptr, J02, cos02, sin02, &yre, &yim);
                       // oscillator 0<->3
-                      Jkl_coupling(it, n0, n3, n0p, n3p, i0, i0p, i3, i3p, stridei0, stridei0p, stridei3, stridei3p, xptr, J03, cos03, sin03, &yre, &yim);
+                      Jkl_coupling(shellctx->dim, it, n0, n3, n0p, n3p, i0, i0p, i3, i3p, stridei0, stridei0p, stridei3, stridei3p, xptr, J03, cos03, sin03, &yre, &yim);
                       // oscillator 0<->4
-                      Jkl_coupling(it, n0, n4, n0p, n4p, i0, i0p, i4, i4p, stridei0, stridei0p, stridei4, stridei4p, xptr, J04, cos04, sin04, &yre, &yim);
+                      Jkl_coupling(shellctx->dim, it, n0, n4, n0p, n4p, i0, i0p, i4, i4p, stridei0, stridei0p, stridei4, stridei4p, xptr, J04, cos04, sin04, &yre, &yim);
                       // oscillator 1<->2
-                      Jkl_coupling(it, n1, n2, n1p, n2p, i1, i1p, i2, i2p, stridei1, stridei1p, stridei2, stridei2p, xptr, J12, cos12, sin12, &yre, &yim);
+                      Jkl_coupling(shellctx->dim, it, n1, n2, n1p, n2p, i1, i1p, i2, i2p, stridei1, stridei1p, stridei2, stridei2p, xptr, J12, cos12, sin12, &yre, &yim);
                       // oscillator 1<->3
-                      Jkl_coupling(it, n1, n3, n1p, n3p, i1, i1p, i3, i3p, stridei1, stridei1p, stridei3, stridei3p, xptr, J13, cos13, sin13, &yre, &yim);
+                      Jkl_coupling(shellctx->dim, it, n1, n3, n1p, n3p, i1, i1p, i3, i3p, stridei1, stridei1p, stridei3, stridei3p, xptr, J13, cos13, sin13, &yre, &yim);
                       // oscillator 1<->4
-                      Jkl_coupling(it, n1, n4, n1p, n4p, i1, i1p, i4, i4p, stridei1, stridei1p, stridei4, stridei4p, xptr, J14, cos14, sin14, &yre, &yim);
+                      Jkl_coupling(shellctx->dim, it, n1, n4, n1p, n4p, i1, i1p, i4, i4p, stridei1, stridei1p, stridei4, stridei4p, xptr, J14, cos14, sin14, &yre, &yim);
                       // oscillator 2<->3
-                      Jkl_coupling(it, n2, n3, n2p, n3p, i2, i2p, i3, i3p, stridei2, stridei2p, stridei3, stridei3p, xptr, J23, cos23, sin23, &yre, &yim);
+                      Jkl_coupling(shellctx->dim, it, n2, n3, n2p, n3p, i2, i2p, i3, i3p, stridei2, stridei2p, stridei3, stridei3p, xptr, J23, cos23, sin23, &yre, &yim);
                       // oscillator 2<->4
-                      Jkl_coupling(it, n2, n4, n2p, n4p, i2, i2p, i4, i4p, stridei2, stridei2p, stridei4, stridei4p, xptr, J24, cos24, sin24, &yre, &yim);
+                      Jkl_coupling(shellctx->dim, it, n2, n4, n2p, n4p, i2, i2p, i4, i4p, stridei2, stridei2p, stridei4, stridei4p, xptr, J24, cos24, sin24, &yre, &yim);
                       // oscillator 3<->4
-                      Jkl_coupling(it, n3, n4, n3p, n4p, i3, i3p, i4, i4p, stridei3, stridei3p, stridei4, stridei4p, xptr, J34, cos34, sin34, &yre, &yim);
+                      Jkl_coupling(shellctx->dim, it, n3, n4, n3p, n4p, i3, i3p, i4, i4p, stridei3, stridei3p, stridei4, stridei4p, xptr, J34, cos34, sin34, &yre, &yim);
 
                       /* --- Offdiagonal part of decay L1 */
                       if (shellctx->lindbladtype != LindbladType::NONE) {
@@ -2828,25 +2828,25 @@ int applyRHS_matfree_transpose(Mat RHS, Vec x, Vec y){
 
                       /* --- Offdiagonal coupling term J_kl --- */
                       // oscillator 0<->1
-                      Jkl_coupling_T(it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
+                      Jkl_coupling_T(shellctx->dim, it, n0, n1, n0p, n1p, i0, i0p, i1, i1p, stridei0, stridei0p, stridei1, stridei1p, xptr, J01, cos01, sin01, &yre, &yim);
                       // oscillator 0<->2
-                      Jkl_coupling_T(it, n0, n2, n0p, n2p, i0, i0p, i2, i2p, stridei0, stridei0p, stridei2, stridei2p, xptr, J02, cos02, sin02, &yre, &yim);
+                      Jkl_coupling_T(shellctx->dim, it, n0, n2, n0p, n2p, i0, i0p, i2, i2p, stridei0, stridei0p, stridei2, stridei2p, xptr, J02, cos02, sin02, &yre, &yim);
                       // oscillator 0<->3
-                      Jkl_coupling_T(it, n0, n3, n0p, n3p, i0, i0p, i3, i3p, stridei0, stridei0p, stridei3, stridei3p, xptr, J03, cos03, sin03, &yre, &yim);
+                      Jkl_coupling_T(shellctx->dim, it, n0, n3, n0p, n3p, i0, i0p, i3, i3p, stridei0, stridei0p, stridei3, stridei3p, xptr, J03, cos03, sin03, &yre, &yim);
                       // oscillator 0<->4
-                      Jkl_coupling_T(it, n0, n4, n0p, n4p, i0, i0p, i4, i4p, stridei0, stridei0p, stridei4, stridei4p, xptr, J04, cos04, sin04, &yre, &yim);
+                      Jkl_coupling_T(shellctx->dim, it, n0, n4, n0p, n4p, i0, i0p, i4, i4p, stridei0, stridei0p, stridei4, stridei4p, xptr, J04, cos04, sin04, &yre, &yim);
                       // oscillator 1<->2
-                      Jkl_coupling_T(it, n1, n2, n1p, n2p, i1, i1p, i2, i2p, stridei1, stridei1p, stridei2, stridei2p, xptr, J12, cos12, sin12, &yre, &yim);
+                      Jkl_coupling_T(shellctx->dim, it, n1, n2, n1p, n2p, i1, i1p, i2, i2p, stridei1, stridei1p, stridei2, stridei2p, xptr, J12, cos12, sin12, &yre, &yim);
                       // oscillator 1<->3
-                      Jkl_coupling_T(it, n1, n3, n1p, n3p, i1, i1p, i3, i3p, stridei1, stridei1p, stridei3, stridei3p, xptr, J13, cos13, sin13, &yre, &yim);
+                      Jkl_coupling_T(shellctx->dim, it, n1, n3, n1p, n3p, i1, i1p, i3, i3p, stridei1, stridei1p, stridei3, stridei3p, xptr, J13, cos13, sin13, &yre, &yim);
                       // oscillator 1<->4
-                      Jkl_coupling_T(it, n1, n4, n1p, n4p, i1, i1p, i4, i4p, stridei1, stridei1p, stridei4, stridei4p, xptr, J14, cos14, sin14, &yre, &yim);
+                      Jkl_coupling_T(shellctx->dim, it, n1, n4, n1p, n4p, i1, i1p, i4, i4p, stridei1, stridei1p, stridei4, stridei4p, xptr, J14, cos14, sin14, &yre, &yim);
                       // oscillator 2<->3
-                      Jkl_coupling_T(it, n2, n3, n2p, n3p, i2, i2p, i3, i3p, stridei2, stridei2p, stridei3, stridei3p, xptr, J23, cos23, sin23, &yre, &yim);
+                      Jkl_coupling_T(shellctx->dim, it, n2, n3, n2p, n3p, i2, i2p, i3, i3p, stridei2, stridei2p, stridei3, stridei3p, xptr, J23, cos23, sin23, &yre, &yim);
                       // oscillator 2<->4
-                      Jkl_coupling_T(it, n2, n4, n2p, n4p, i2, i2p, i4, i4p, stridei2, stridei2p, stridei4, stridei4p, xptr, J24, cos24, sin24, &yre, &yim);
+                      Jkl_coupling_T(shellctx->dim, it, n2, n4, n2p, n4p, i2, i2p, i4, i4p, stridei2, stridei2p, stridei4, stridei4p, xptr, J24, cos24, sin24, &yre, &yim);
                       // oscillator 3<->4
-                      Jkl_coupling_T(it, n3, n4, n3p, n4p, i3, i3p, i4, i4p, stridei3, stridei3p, stridei4, stridei4p, xptr, J34, cos34, sin34, &yre, &yim);
+                      Jkl_coupling_T(shellctx->dim, it, n3, n4, n3p, n4p, i3, i3p, i4, i4p, stridei3, stridei3p, stridei4, stridei4p, xptr, J34, cos34, sin34, &yre, &yim);
               
                       /* --- Offdiagonal part of decay L1^T */
                       if (shellctx->lindbladtype != LindbladType::NONE) { 

--- a/src/optimtarget.cpp
+++ b/src/optimtarget.cpp
@@ -111,7 +111,7 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
           j = mapEssToFull(j, mastereq->nlevels, mastereq->nessential);
         }
         PetscInt elemid_re = getIndexReal(getVecID(k,j,dim_rho));
-        PetscInt elemid_im = getIndexImag(getVecID(k,j,dim_rho));
+        PetscInt elemid_im = getIndexImag(getVecID(k,j,dim_rho), dim);
         if (ilow <= elemid_re && elemid_re < iupp) VecSetValue(rho_t0, elemid_re, vec[i], INSERT_VALUES);        // RealPart
         if (ilow <= elemid_im && elemid_im < iupp) VecSetValue(rho_t0, elemid_im, vec[i + dim_ess*dim_ess], INSERT_VALUES); // Imaginary Part
       }
@@ -121,7 +121,7 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
         if (dim_ess < mastereq->getDim()) 
           k = mapEssToFull(i, mastereq->nlevels, mastereq->nessential);
         PetscInt elemid_re = getIndexReal(k);
-        PetscInt elemid_im = getIndexImag(k);
+        PetscInt elemid_im = getIndexImag(k, dim);
         if (ilow <= elemid_re && elemid_re < iupp) VecSetValue(rho_t0, elemid_re, vec[i], INSERT_VALUES);        // RealPart
         if (ilow <= elemid_im && elemid_im < iupp) VecSetValue(rho_t0, elemid_im, vec[i + dim_ess], INSERT_VALUES); // Imaginary Part
       }
@@ -161,12 +161,12 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
         } else {
           // upper diagonal (0.5 + 0.5*i) / (N_sub^2)
           PetscInt elemid_re = getIndexReal(getVecID(ifull, jfull, dimrho));
-          PetscInt elemid_im = getIndexImag(getVecID(ifull, jfull, dimrho));
+          PetscInt elemid_im = getIndexImag(getVecID(ifull, jfull, dimrho), dim);
           if (ilow <= elemid_re && elemid_re < iupp) VecSetValue(rho_t0, elemid_re, 0.5/(dimsub*dimsub), INSERT_VALUES);
           if (ilow <= elemid_im && elemid_im < iupp) VecSetValue(rho_t0, elemid_im, 0.5/(dimsub*dimsub), INSERT_VALUES);
           // lower diagonal (0.5 - 0.5*i) / (N_sub^2)
           elemid_re = getIndexReal(getVecID(jfull, ifull, dimrho));
-          elemid_im = getIndexImag(getVecID(jfull, ifull, dimrho));
+          elemid_im = getIndexImag(getVecID(jfull, ifull, dimrho), dim);
           if (ilow <= elemid_re && elemid_re < iupp) VecSetValue(rho_t0, elemid_re,  0.5/(dimsub*dimsub), INSERT_VALUES);
           if (ilow <= elemid_im && elemid_im < iupp) VecSetValue(rho_t0, elemid_im, -0.5/(dimsub*dimsub), INSERT_VALUES);
         } 
@@ -259,7 +259,7 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
           j = mapEssToFull(j, mastereq->nlevels, mastereq->nessential);
         }
         PetscInt elemid_re = getIndexReal(getVecID(k,j,dim_rho));
-        PetscInt elemid_im = getIndexImag(getVecID(k,j,dim_rho));
+        PetscInt elemid_im = getIndexImag(getVecID(k,j,dim_rho), dim);
         if (ilow <= elemid_re && elemid_re < iupp) VecSetValue(targetstate, elemid_re, vec[i],       INSERT_VALUES); // RealPart
         if (ilow <= elemid_im && elemid_im < iupp) VecSetValue(targetstate, elemid_im, vec[i + dim_ess*dim_ess], INSERT_VALUES); // Imaginary Part
       }
@@ -269,7 +269,7 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
         if (dim_ess < mastereq->getDim()) 
           k = mapEssToFull(i, mastereq->nlevels, mastereq->nessential);
         PetscInt elemid_re = getIndexReal(k);
-        PetscInt elemid_im = getIndexImag(k);
+        PetscInt elemid_im = getIndexImag(k, dim);
         if (ilow <= elemid_re && elemid_re < iupp) VecSetValue(targetstate, elemid_re, vec[i], INSERT_VALUES);        // RealPart
         if (ilow <= elemid_im && elemid_im < iupp) VecSetValue(targetstate, elemid_im, vec[i + dim_ess], INSERT_VALUES); // Imaginary Part
       }
@@ -326,7 +326,7 @@ void OptimTarget::HilbertSchmidtOverlap(const Vec state, const bool scalebypurit
     PetscInt idm = purestateID;
     if (lindbladtype != LindbladType::NONE) idm = getVecID(purestateID, purestateID, (PetscInt)sqrt(dim));
     PetscInt idm_re = getIndexReal(idm);
-    PetscInt idm_im = getIndexImag(idm);
+    PetscInt idm_im = getIndexImag(idm, dim);
     if (ilo <= idm_re && idm_re < ihi) VecGetValues(state, 1, &idm_re, &HS_re); // local!
     if (ilo <= idm_im && idm_im < ihi) VecGetValues(state, 1, &idm_im, &HS_im); // local! Should be 0.0 if Lindblad!
     if (lindbladtype != LindbladType::NONE) assert(fabs(HS_im) <= 1e-14);
@@ -350,7 +350,7 @@ void OptimTarget::HilbertSchmidtOverlap(const Vec state, const bool scalebypurit
       VecGetOwnershipRange(state, &ilo, &ihi);
       for (PetscInt i=0; i<dim; i++){
         PetscInt ia = getIndexReal(i);
-        PetscInt ib = getIndexImag(i);
+        PetscInt ib = getIndexImag(i, dim);
         if (ilo <= ia && ia < ihi) {
           PetscInt idre = ia - ilo;
           PetscInt idim = ib - ilo;
@@ -392,7 +392,7 @@ void OptimTarget::HilbertSchmidtOverlap_diff(const Vec state, Vec statebar, bool
     PetscInt idm = purestateID;
     if (lindbladtype != LindbladType::NONE) idm = getVecID(purestateID, purestateID, (PetscInt)sqrt(dim));
     PetscInt idm_re = getIndexReal(idm);
-    PetscInt idm_im = getIndexImag(idm);
+    PetscInt idm_im = getIndexImag(idm, dim);
     if (ilo <= idm_re && idm_re < ihi) VecSetValue(statebar, idm_re, HS_re_bar*scale, ADD_VALUES);
     if (ilo <= idm_im && idm_im < ihi) VecSetValue(statebar, idm_im, HS_im_bar, ADD_VALUES);
 
@@ -409,7 +409,7 @@ void OptimTarget::HilbertSchmidtOverlap_diff(const Vec state, Vec statebar, bool
       VecGetOwnershipRange(state, &ilo, &ihi);
       for (PetscInt i=0; i<dim; i++){
         PetscInt ia = getIndexReal(i);
-        PetscInt ib = getIndexImag(i);
+        PetscInt ib = getIndexImag(i, dim);
         if (ilo <= ia && ia < ihi) {
           PetscInt idre = ia - ilo;
           PetscInt idim = ib - ilo;
@@ -442,7 +442,7 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, const std
       for (PetscInt i=0; i<dim_rho; i++){
         if (lindbladtype == LindbladType::NONE) {
           PetscInt elem_re = getIndexReal(i);
-          PetscInt elem_im = getIndexImag(i);
+          PetscInt elem_im = getIndexImag(i, dim);
           double val = 1./ sqrt(2.*dim_rho);
           if (ilow <= elem_re && elem_re < iupp) VecSetValue(rho0, elem_re, val, INSERT_VALUES);
           if (ilow <= elem_im && elem_im < iupp) VecSetValue(rho0, elem_im, val, INSERT_VALUES);
@@ -624,8 +624,8 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, const std
           }
           vals[2] = -0.5;
           vals[3] = 0.5;
-          rows[2] = getIndexImag(getVecID(k, j, dim_rho)); // (k,j)
-          rows[3] = getIndexImag(getVecID(j, k, dim_rho)); // (j,k)
+          rows[2] = getIndexImag(getVecID(k, j, dim_rho), dim); // (k,j)
+          rows[3] = getIndexImag(getVecID(j, k, dim_rho), dim); // (j,k)
           for (int i=2; i<4; i++) {
             if (ilow <= rows[i] && rows[i] < iupp) VecSetValues(rho0, 1, &(rows[i]), &(vals[i]), INSERT_VALUES);
           }
@@ -719,7 +719,7 @@ void OptimTarget::evalJ(const Vec state, double* J_re_ptr, double* J_im_ptr){
           if (ilo <= diagID && diagID < ihi) VecGetValues(state, 1, &diagID, &rhoii);
         } else  {
           diagID_re = getIndexReal(i);
-          diagID_im = getIndexImag(i);
+          diagID_im = getIndexImag(i, dim);
           rhoii_re = 0.0;
           rhoii_im = 0.0;
           if (ilo <= diagID_re && diagID_re < ihi) VecGetValues(state, 1, &diagID_re, &rhoii_re);
@@ -783,7 +783,7 @@ void OptimTarget::evalJ_diff(const Vec state, Vec statebar, const double J_re_ba
           if (ilo <= diagID && diagID < ihi) VecSetValue(statebar, diagID, val, ADD_VALUES);
         } else {
           diagID_re = getIndexReal(i);
-          diagID_im = getIndexImag(i);
+          diagID_im = getIndexImag(i, dim);
           rhoii_re = 0.0;
           rhoii_im = 0.0;
           if (ilo <= diagID_re && diagID_re < ihi) VecGetValues(state, 1, &diagID_re, &rhoii_re);

--- a/src/optimtarget.cpp
+++ b/src/optimtarget.cpp
@@ -14,6 +14,8 @@ OptimTarget::OptimTarget(){
   purestateID = -1;
   target_filename = "";
   targetstate = NULL;
+  mpisize_petsc=0;
+  mpirank_petsc=0;
 }
 
 
@@ -25,10 +27,19 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
   dim_ess = mastereq->getDimEss();
   quietmode = quietmode_;
   lindbladtype = mastereq->lindbladtype;
-
-  // Get global communicator rank
+  MPI_Comm_size(PETSC_COMM_WORLD, &mpisize_petsc);
+  MPI_Comm_rank(PETSC_COMM_WORLD, &mpirank_petsc);
   int mpirank_world;
+  int mpisize_petsc;
   MPI_Comm_rank(MPI_COMM_WORLD, &mpirank_world);
+  MPI_Comm_size(PETSC_COMM_WORLD, &mpisize_petsc);
+  // Get locally owned portion of state vector
+  localsize_u = dim / mpisize_petsc;
+  VecGetOwnershipRange(rho_t0, &ilow, &iupp);
+  ilow = ilow / 2;
+  iupp = ilow + localsize_u;
+
+ 
 
   /* Get initial condition type */
   if (initcond_str[0].compare("file") == 0)              initcond_type = InitialConditionType::FROMFILE;
@@ -63,14 +74,13 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
     initcond_IDs.push_back(atoi(initcond_str[i].c_str())); // Overwrite with config option, if given.
 
   /* Prepare initial state rho_t0 if PURE or FROMFILE or ENSEMBLE initialization. Otherwise they are set within prepareInitialState during evalF. */
-  PetscInt ilow, iupp;
-  VecGetOwnershipRange(rho_t0, &ilow, &iupp);
   if (initcond_type == InitialConditionType::PURE) { 
     /* Initialize with tensor product of unit vectors. */
     if (initcond_IDs.size() != mastereq->getNOscillators()) {
       printf("ERROR during pure-state initialization: List of IDs must contain %zu elements!\n", mastereq->getNOscillators());
       exit(1);
     }
+    // Find the id within the global composite system 
     PetscInt diag_id = 0;
     for (size_t k=0; k < initcond_IDs.size(); k++) {
       if (initcond_IDs[k] > mastereq->getOscillator(k)->getNLevels()-1){
@@ -84,11 +94,15 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
       }
       diag_id += initcond_IDs[k] * dim_postkron;
     }
-    PetscInt ndim = mastereq->getDimRho();
-    PetscInt vec_id = -1;
-    if (lindbladtype != LindbladType::NONE) vec_id = getIndexReal(getVecID( diag_id, diag_id, ndim )); // Real part of x
-    else vec_id = getIndexReal(diag_id);
-    if (ilow <= vec_id && vec_id < iupp) VecSetValue(rho_t0, vec_id, 1.0, INSERT_VALUES);
+    // Vectorize if lindblad solver
+    PetscInt vec_id = diag_id;
+    if (lindbladtype != LindbladType::NONE) vec_id = getVecID( diag_id, diag_id, dim_rho); 
+    // Set 1.0 on the processor who owns this index
+    printf("ilow %d, iupp %d, vec_id %d\n", ilow, iupp, vec_id);
+    if (ilow <= vec_id && vec_id < iupp) {
+      PetscInt id_global_x =  vec_id + mpirank_petsc*localsize_u; // Global index of u_i in x=[u,v]
+      VecSetValue(rho_t0, id_global_x, 1.0, INSERT_VALUES);
+    }
   }
   else if (initcond_type == InitialConditionType::FROMFILE) { 
     /* Read initial condition from file */
@@ -110,20 +124,24 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
           k = mapEssToFull(k, mastereq->nlevels, mastereq->nessential);
           j = mapEssToFull(j, mastereq->nlevels, mastereq->nessential);
         }
-        PetscInt elemid_re = getIndexReal(getVecID(k,j,dim_rho));
-        PetscInt elemid_im = getIndexImag(getVecID(k,j,dim_rho), dim);
-        if (ilow <= elemid_re && elemid_re < iupp) VecSetValue(rho_t0, elemid_re, vec[i], INSERT_VALUES);        // RealPart
-        if (ilow <= elemid_im && elemid_im < iupp) VecSetValue(rho_t0, elemid_im, vec[i + dim_ess*dim_ess], INSERT_VALUES); // Imaginary Part
+        PetscInt elemid = getVecID(k,j,dim_rho);
+        if (ilow <= elemid && elemid < iupp) {
+          PetscInt id_global_x =  elemid + mpirank_petsc*localsize_u; // Global index of u_i in x=[u,v]
+          VecSetValue(rho_t0, id_global_x, vec[i], INSERT_VALUES);  // RealPart
+          VecSetValue(rho_t0, id_global_x + localsize_u, vec[i + dim_ess*dim_ess], INSERT_VALUES); // Imaginary Part
+        }
       }
     } else { // Schroedinger solver, fill vector 
       for (PetscInt i = 0; i < dim_ess; i++) {
         PetscInt k = i;
         if (dim_ess < mastereq->getDim()) 
           k = mapEssToFull(i, mastereq->nlevels, mastereq->nessential);
-        PetscInt elemid_re = getIndexReal(k);
-        PetscInt elemid_im = getIndexImag(k, dim);
-        if (ilow <= elemid_re && elemid_re < iupp) VecSetValue(rho_t0, elemid_re, vec[i], INSERT_VALUES);        // RealPart
-        if (ilow <= elemid_im && elemid_im < iupp) VecSetValue(rho_t0, elemid_im, vec[i + dim_ess], INSERT_VALUES); // Imaginary Part
+        PetscInt elemid = k;
+        if (ilow <= elemid && elemid < iupp) {
+          PetscInt id_global_x =  elemid + mpirank_petsc*localsize_u; // Global index of u_i in x=[u,v]
+          VecSetValue(rho_t0, id_global_x, vec[i], INSERT_VALUES);  // RealPart
+          VecSetValue(rho_t0, id_global_x + localsize_u, vec[i + dim_ess], INSERT_VALUES); // Imaginary Part
+        }
       }
     }
     delete [] vec;
@@ -156,19 +174,26 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
         // printf(" i=%d j=%d ifull %d, jfull %d\n", i, j, ifull, jfull);
         if (i == j) { 
           // diagonal element: 1/N_sub
-          PetscInt elemid_re = getIndexReal(getVecID(ifull, jfull, dimrho));
-          if (ilow <= elemid_re && elemid_re < iupp) VecSetValue(rho_t0, elemid_re, 1./dimsub, INSERT_VALUES);
+          PetscInt elemid = getVecID(ifull, jfull, dimrho);
+          if (ilow <= elemid && elemid < iupp) {
+            PetscInt id_global_x =  elemid + mpirank_petsc*localsize_u; // Global index of u_i in x=[u,v]
+            VecSetValue(rho_t0, id_global_x, 1./dimsub, INSERT_VALUES);
+          }
         } else {
           // upper diagonal (0.5 + 0.5*i) / (N_sub^2)
-          PetscInt elemid_re = getIndexReal(getVecID(ifull, jfull, dimrho));
-          PetscInt elemid_im = getIndexImag(getVecID(ifull, jfull, dimrho), dim);
-          if (ilow <= elemid_re && elemid_re < iupp) VecSetValue(rho_t0, elemid_re, 0.5/(dimsub*dimsub), INSERT_VALUES);
-          if (ilow <= elemid_im && elemid_im < iupp) VecSetValue(rho_t0, elemid_im, 0.5/(dimsub*dimsub), INSERT_VALUES);
+          PetscInt elemid = getVecID(ifull, jfull, dimrho);
+          if (ilow <= elemid && elemid < iupp) {
+            PetscInt id_global_x =  elemid + mpirank_petsc*localsize_u; // Global index of u_i in x=[u,v]
+            VecSetValue(rho_t0, id_global_x, 0.5/(dimsub*dimsub), INSERT_VALUES);
+            VecSetValue(rho_t0, id_global_x + localsize_u, 0.5/(dimsub*dimsub), INSERT_VALUES);
+          }
           // lower diagonal (0.5 - 0.5*i) / (N_sub^2)
-          elemid_re = getIndexReal(getVecID(jfull, ifull, dimrho));
-          elemid_im = getIndexImag(getVecID(jfull, ifull, dimrho), dim);
-          if (ilow <= elemid_re && elemid_re < iupp) VecSetValue(rho_t0, elemid_re,  0.5/(dimsub*dimsub), INSERT_VALUES);
-          if (ilow <= elemid_im && elemid_im < iupp) VecSetValue(rho_t0, elemid_im, -0.5/(dimsub*dimsub), INSERT_VALUES);
+          elemid = getVecID(jfull, ifull, dimrho);
+          if (ilow <= elemid && elemid < iupp) {
+            PetscInt id_global_x =  elemid + mpirank_petsc*localsize_u; // Global index of u_i in x=[u,v]
+            VecSetValue(rho_t0, id_global_x,  0.5/(dimsub*dimsub), INSERT_VALUES);
+            VecSetValue(rho_t0, id_global_x + localsize_u, -0.5/(dimsub*dimsub), INSERT_VALUES);
+          }
         } 
       }
     }
@@ -237,7 +262,9 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
   /* Allocate target state, if it is read from file, or if target is a gate transformation VrhoV. If pure target, only store the ID. */
   if (target_type == TargetType::GATE || target_type == TargetType::FROMFILE) {
     VecCreate(PETSC_COMM_WORLD, &targetstate); 
-    VecSetSizes(targetstate,PETSC_DECIDE, 2*dim);   // input dim is either N^2 (lindblad eq) or N (schroedinger eq)
+    PetscInt globalsize = 2 * mastereq->getDim();  // Global state vector: 2 for real and imaginary part
+    PetscInt localsize = globalsize / mpisize_petsc;  // Local vector per processor
+    VecSetSizes(targetstate,localsize,globalsize);
     VecSetFromOptions(targetstate);
   }
 
@@ -258,20 +285,24 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
           k = mapEssToFull(k, mastereq->nlevels, mastereq->nessential);
           j = mapEssToFull(j, mastereq->nlevels, mastereq->nessential);
         }
-        PetscInt elemid_re = getIndexReal(getVecID(k,j,dim_rho));
-        PetscInt elemid_im = getIndexImag(getVecID(k,j,dim_rho), dim);
-        if (ilow <= elemid_re && elemid_re < iupp) VecSetValue(targetstate, elemid_re, vec[i],       INSERT_VALUES); // RealPart
-        if (ilow <= elemid_im && elemid_im < iupp) VecSetValue(targetstate, elemid_im, vec[i + dim_ess*dim_ess], INSERT_VALUES); // Imaginary Part
+        PetscInt elemid = getVecID(k,j,dim_rho);
+        if (ilow <= elemid && elemid < iupp) {
+          PetscInt id_global_x =  elemid + mpirank_petsc*localsize_u; // Global index of u_i in x=[u,v]
+          VecSetValue(targetstate, id_global_x, vec[i],       INSERT_VALUES); // RealPart
+          VecSetValue(targetstate, id_global_x + localsize_u, vec[i + dim_ess*dim_ess], INSERT_VALUES); // Imaginary Part
+        }
       }
     } else {  // Schroedinger solver, fill vector
       for (int i = 0; i < dim_ess; i++) {
         int k = i;
         if (dim_ess < mastereq->getDim()) 
           k = mapEssToFull(i, mastereq->nlevels, mastereq->nessential);
-        PetscInt elemid_re = getIndexReal(k);
-        PetscInt elemid_im = getIndexImag(k, dim);
-        if (ilow <= elemid_re && elemid_re < iupp) VecSetValue(targetstate, elemid_re, vec[i], INSERT_VALUES);        // RealPart
-        if (ilow <= elemid_im && elemid_im < iupp) VecSetValue(targetstate, elemid_im, vec[i + dim_ess], INSERT_VALUES); // Imaginary Part
+        PetscInt elemid = k;
+        if (ilow <= elemid && elemid < iupp) {
+          PetscInt id_global_x =  elemid + mpirank_petsc*localsize_u; // Global index of u_i in x=[u,v]
+          VecSetValue(targetstate, id_global_x, vec[i], INSERT_VALUES);        // RealPart
+          VecSetValue(targetstate, id_global_x + localsize_u, vec[i + dim_ess], INSERT_VALUES); // Imaginary Part
+        }
       }
     }
     VecAssemblyBegin(targetstate); VecAssemblyEnd(targetstate);
@@ -281,7 +312,9 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
   /* Allocate an auxiliary vec needed for evaluating the frobenius norm */
   if (objective_type == ObjectiveType::JFROBENIUS) {
     VecCreate(PETSC_COMM_WORLD, &aux); 
-    VecSetSizes(aux,PETSC_DECIDE, 2*dim);
+    PetscInt globalsize = 2 * mastereq->getDim();  // 2 for real and imaginary part
+    PetscInt localsize = globalsize / mpisize_petsc;  // Local vector per processor
+    VecSetSizes(aux,localsize, globalsize);
     VecSetFromOptions(aux);
   }
 }
@@ -314,21 +347,26 @@ void OptimTarget::FrobeniusDistance_diff(const Vec state, Vec statebar, const do
 void OptimTarget::HilbertSchmidtOverlap(const Vec state, const bool scalebypurity, double* HS_re_ptr, double* HS_im_ptr ){
   /* Lindblas solver: Tr(state * target^\dagger) = vec(target)^dagger * vec(state), will be real!
    * Schroedinger:    Tr(state * target^\dagger) = target^\dag * state, will be complex!*/
+
+  // Reset
   double HS_re = 0.0;
   double HS_im = 0.0;
 
   /* Simplify computation if the target is PURE, i.e. target = e_m or e_m * e_m^\dag */
   /* Tr(...) = phi_m if Schroedinger, or \rho_mm if Lindblad */
   if (target_type == TargetType::PURE){
-    PetscInt ilo, ihi;
-    VecGetOwnershipRange(state, &ilo, &ihi);
 
+    // Vectorize pure state ID if Lindblad
     PetscInt idm = purestateID;
     if (lindbladtype != LindbladType::NONE) idm = getVecID(purestateID, purestateID, (PetscInt)sqrt(dim));
-    PetscInt idm_re = getIndexReal(idm);
-    PetscInt idm_im = getIndexImag(idm, dim);
-    if (ilo <= idm_re && idm_re < ihi) VecGetValues(state, 1, &idm_re, &HS_re); // local!
-    if (ilo <= idm_im && idm_im < ihi) VecGetValues(state, 1, &idm_im, &HS_im); // local! Should be 0.0 if Lindblad!
+
+    // Get real and imag values from the processor who owns the subvector index.
+    if (ilow <= idm && idm < iupp) {
+      PetscInt id_global_x = idm + mpirank_petsc*localsize_u; // Global index of u_i in x=[u,v]
+      VecGetValues(state, 1, &id_global_x, &HS_re);
+      id_global_x += localsize_u; // Imaginary part
+      VecGetValues(state, 1, &id_global_x, &HS_im); // Should be 0.0 if Lindblad!
+    }
     if (lindbladtype != LindbladType::NONE) assert(fabs(HS_im) <= 1e-14);
 
     // Communicate over all petsc processors.
@@ -342,21 +380,16 @@ void OptimTarget::HilbertSchmidtOverlap(const Vec state, const bool scalebypurit
     if (lindbladtype != LindbladType::NONE) // Lindblad solver. HS overlap is real!
       VecTDot(targetstate, state, &HS_re);  
     else {  // Schroedinger solver. target^\dagger * state
+      // Get local data pointers
       const PetscScalar* target_ptr;
       const PetscScalar* state_ptr;
-      VecGetArrayRead(targetstate, &target_ptr); // these are local vectors
+      VecGetArrayRead(targetstate, &target_ptr); 
       VecGetArrayRead(state, &state_ptr);
-      PetscInt ilo, ihi;
-      VecGetOwnershipRange(state, &ilo, &ihi);
-      for (PetscInt i=0; i<dim; i++){
-        PetscInt ia = getIndexReal(i);
-        PetscInt ib = getIndexImag(i, dim);
-        if (ilo <= ia && ia < ihi) {
-          PetscInt idre = ia - ilo;
-          PetscInt idim = ib - ilo;
-          HS_re +=  target_ptr[idre]*state_ptr[idre] + target_ptr[idim]*state_ptr[idim];
-          HS_im += -target_ptr[idim]*state_ptr[idre] + target_ptr[idre]*state_ptr[idim];
-        }
+      for (PetscInt i=0; i<localsize_u; i++){
+        PetscInt idre = i;
+        PetscInt idim = i + localsize_u;
+        HS_re +=  target_ptr[idre]*state_ptr[idre] + target_ptr[idim]*state_ptr[idim];
+        HS_im += -target_ptr[idim]*state_ptr[idre] + target_ptr[idre]*state_ptr[idim];
       } 
       VecRestoreArrayRead(targetstate, &target_ptr);
       VecRestoreArrayRead(state, &state_ptr);
@@ -387,14 +420,14 @@ void OptimTarget::HilbertSchmidtOverlap_diff(const Vec state, Vec statebar, bool
 
   // Simplified computation if target is pure 
   if (target_type == TargetType::PURE){
-    PetscInt ilo, ihi;
-    VecGetOwnershipRange(state, &ilo, &ihi);
     PetscInt idm = purestateID;
     if (lindbladtype != LindbladType::NONE) idm = getVecID(purestateID, purestateID, (PetscInt)sqrt(dim));
-    PetscInt idm_re = getIndexReal(idm);
-    PetscInt idm_im = getIndexImag(idm, dim);
-    if (ilo <= idm_re && idm_re < ihi) VecSetValue(statebar, idm_re, HS_re_bar*scale, ADD_VALUES);
-    if (ilo <= idm_im && idm_im < ihi) VecSetValue(statebar, idm_im, HS_im_bar, ADD_VALUES);
+
+    if (ilow <= idm && idm < iupp) {
+      PetscInt id_global_x = idm + mpirank_petsc*localsize_u; // Global index of u_i in x=[u,v]
+      VecSetValue(statebar, id_global_x, HS_re_bar*scale, ADD_VALUES);
+      VecSetValue(statebar, id_global_x + localsize_u, HS_im_bar, ADD_VALUES);
+    }
 
   } else { // Target is not of the form e_m or e_m*e_m^\dagger 
 
@@ -405,17 +438,11 @@ void OptimTarget::HilbertSchmidtOverlap_diff(const Vec state, Vec statebar, bool
       PetscScalar* statebar_ptr;
       VecGetArrayRead(targetstate, &target_ptr); 
       VecGetArray(statebar, &statebar_ptr);
-      PetscInt ilo, ihi;
-      VecGetOwnershipRange(state, &ilo, &ihi);
-      for (PetscInt i=0; i<dim; i++){
-        PetscInt ia = getIndexReal(i);
-        PetscInt ib = getIndexImag(i, dim);
-        if (ilo <= ia && ia < ihi) {
-          PetscInt idre = ia - ilo;
-          PetscInt idim = ib - ilo;
-          statebar_ptr[idre] += target_ptr[idre] * HS_re_bar*scale  - target_ptr[idim] * HS_im_bar;
-          statebar_ptr[idim] += target_ptr[idim] * HS_re_bar*scale  + target_ptr[idre] * HS_im_bar;
-        }
+      for (PetscInt i=0; i<localsize_u; i++){
+        PetscInt idre = i;
+        PetscInt idim = i + localsize_u;
+        statebar_ptr[idre] += target_ptr[idre] * HS_re_bar*scale  - target_ptr[idim] * HS_im_bar;
+        statebar_ptr[idim] += target_ptr[idim] * HS_re_bar*scale  + target_ptr[idre] * HS_im_bar;
       }
       VecRestoreArrayRead(targetstate, &target_ptr);
       VecRestoreArray(statebar, &statebar_ptr);
@@ -426,7 +453,6 @@ void OptimTarget::HilbertSchmidtOverlap_diff(const Vec state, Vec statebar, bool
 
 int OptimTarget::prepareInitialState(const int iinit, const int ninit, const std::vector<int>& nlevels, const std::vector<int>& nessential, Vec rho0){
 
-  PetscInt ilow, iupp; 
   PetscInt elemID;
   double val;
   PetscInt dim_post;
@@ -438,18 +464,22 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, const std
     case InitialConditionType::PERFORMANCE:
       /* Set up Input state psi = 1/sqrt(2N)*(Ones(N) + im*Ones(N)) or rho = psi*psi^\dag */
       VecZeroEntries(rho0);
-      VecGetOwnershipRange(rho0, &ilow, &iupp);
+
       for (PetscInt i=0; i<dim_rho; i++){
         if (lindbladtype == LindbladType::NONE) {
-          PetscInt elem_re = getIndexReal(i);
-          PetscInt elem_im = getIndexImag(i, dim);
           double val = 1./ sqrt(2.*dim_rho);
-          if (ilow <= elem_re && elem_re < iupp) VecSetValue(rho0, elem_re, val, INSERT_VALUES);
-          if (ilow <= elem_im && elem_im < iupp) VecSetValue(rho0, elem_im, val, INSERT_VALUES);
+          if (ilow <= i && i < iupp) {
+            PetscInt id_global_x =  i + mpirank_petsc*localsize_u; // Global index of u_i in x=[u,v]
+            VecSetValue(rho0, id_global_x, val, INSERT_VALUES);
+            VecSetValue(rho0, id_global_x + localsize_u, val, INSERT_VALUES);
+          }
         } else {
-          PetscInt elem_re = getIndexReal(getVecID(i, i, dim_rho));
+          PetscInt elem_re = getVecID(i, i, dim_rho);
           double val = 1./ dim_rho;
-          if (ilow <= elem_re && elem_re < iupp) VecSetValue(rho0, elem_re, val, INSERT_VALUES);
+          if (ilow <= elem_re && elem_re < iupp) {
+            PetscInt id_global_x =  i + mpirank_petsc*localsize_u; // Global index of u_i in x=[u,v]
+            VecSetValue(rho0, id_global_x, val, INSERT_VALUES);
+          }
         }
       }
       break;
@@ -469,16 +499,18 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, const std
     case InitialConditionType::THREESTATES:
       assert(lindbladtype != LindbladType::NONE);
       VecZeroEntries(rho0);
-      VecGetOwnershipRange(rho0, &ilow, &iupp);
 
       /* Set the <iinit>'th initial state */
       if (iinit == 0) {
         // 1st initial state: rho(0)_IJ = 2(N-i)/(N(N+1)) Delta_IJ
         initID = 1;
         for (PetscInt i_full = 0; i_full<dim_rho; i_full++) {
-          PetscInt diagID = getIndexReal(getVecID(i_full,i_full,dim_rho));
+          PetscInt diagID = getVecID(i_full,i_full,dim_rho);
           double val = 2.*(dim_rho - i_full) / (dim_rho * (dim_rho + 1));
-          if (ilow <= diagID && diagID < iupp) VecSetValue(rho0, diagID, val, INSERT_VALUES);
+          if (ilow <= diagID && diagID < iupp) {
+            PetscInt id_global_x =  diagID + mpirank_petsc*localsize_u; // Global index of u_i in x=[u,v]
+            VecSetValue(rho0, id_global_x, val, INSERT_VALUES);
+          }
         }
       } else if (iinit == 1) {
         // 2nd initial state: rho(0)_IJ = 1/N
@@ -486,17 +518,23 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, const std
         for (PetscInt i_full = 0; i_full<dim_rho; i_full++) {
           for (PetscInt j_full = 0; j_full<dim_rho; j_full++) {
             double val = 1./dim_rho;
-            PetscInt index = getIndexReal(getVecID(i_full,j_full,dim_rho));   // Re(rho_ij)
-            if (ilow <= index && index < iupp) VecSetValue(rho0, index, val, INSERT_VALUES); 
+            PetscInt index = getVecID(i_full,j_full,dim_rho);   // Re(rho_ij)
+            if (ilow <= index && index < iupp) {
+              PetscInt id_global_x =  index + mpirank_petsc*localsize_u;
+              VecSetValue(rho0, id_global_x, val, INSERT_VALUES); 
+            }
           }
         }
       } else if (iinit == 2) {
         // 3rd initial state: rho(0)_IJ = 1/N Delta_IJ
         initID = 3;
         for (PetscInt i_full = 0; i_full<dim_rho; i_full++) {
-          PetscInt diagID = getIndexReal(getVecID(i_full,i_full,dim_rho));
+          PetscInt diagID = getVecID(i_full,i_full,dim_rho);
           double val = 1./ dim_rho;
-          if (ilow <= diagID && diagID < iupp) VecSetValue(rho0, diagID, val, INSERT_VALUES);
+          if (ilow <= diagID && diagID < iupp) {
+            PetscInt id_global_x =  diagID + mpirank_petsc*localsize_u;
+            VecSetValue(rho0, id_global_x, val, INSERT_VALUES);
+          }
         }
       } else {
         printf("ERROR: Wrong initial condition setting! Should never happen.\n");
@@ -507,20 +545,25 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, const std
 
     case InitialConditionType::NPLUSONE:
       assert(lindbladtype != LindbladType::NONE);
-      VecGetOwnershipRange(rho0, &ilow, &iupp);
 
       if (iinit < dim_rho) {// Diagonal e_j e_j^\dag
         VecZeroEntries(rho0);
-        elemID = getIndexReal(getVecID(iinit, iinit, dim_rho));
+        elemID = getVecID(iinit, iinit, dim_rho);
         val = 1.0;
-        if (ilow <= elemID && elemID < iupp) VecSetValues(rho0, 1, &elemID, &val, INSERT_VALUES);
+        if (ilow <= elemID && elemID < iupp) {
+          PetscInt id_global_x = elemID+ mpirank_petsc*localsize_u;
+          VecSetValues(rho0, 1, &id_global_x, &val, INSERT_VALUES);
+        }
       }
       else if (iinit == dim_rho) { // fully rotated 1/d*Ones(d)
         for (PetscInt i=0; i<dim_rho; i++){
           for (PetscInt j=0; j<dim_rho; j++){
-            elemID = getIndexReal(getVecID(i,j,dim_rho));
+            elemID = getVecID(i,j,dim_rho);
             val = 1.0 / dim_rho;
-            if (ilow <= elemID && elemID < iupp) VecSetValues(rho0, 1, &elemID, &val, INSERT_VALUES);
+            if (ilow <= elemID && elemID < iupp) {
+              PetscInt id_global_x = elemID + mpirank_petsc*localsize_u;
+              VecSetValues(rho0, 1, &id_global_x, &val, INSERT_VALUES);
+            }
           }
         }
       }
@@ -547,12 +590,14 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, const std
       diagelem = iinit * dim_post;
       if (dim_ess < dim_rho)  diagelem = mapEssToFull(diagelem, nlevels, nessential);
 
-      /* Set B_{mm} */
-      if (lindbladtype != LindbladType::NONE) elemID = getIndexReal(getVecID(diagelem, diagelem, dim_rho)); // density matrix
-      else  elemID = getIndexReal(diagelem); 
+      // Vectorize if Lindblad
+      elemID = diagelem;
+      if (lindbladtype != LindbladType::NONE) elemID = getVecID(diagelem, diagelem, dim_rho); 
       val = 1.0;
-      VecGetOwnershipRange(rho0, &ilow, &iupp);
-      if (ilow <= elemID && elemID < iupp) VecSetValues(rho0, 1, &elemID, &val, INSERT_VALUES);
+      if (ilow <= elemID && elemID < iupp) {
+        PetscInt id_global_x =  elemID + mpirank_petsc*localsize_u; 
+        VecSetValues(rho0, 1, &id_global_x, &val, INSERT_VALUES);
+      }
       VecAssemblyBegin(rho0); VecAssemblyEnd(rho0);
 
       /* Set initial conditon ID */
@@ -566,9 +611,6 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, const std
 
       /* Reset the initial conditions */
       VecZeroEntries(rho0);
-
-      /* Get distribution */
-      VecGetOwnershipRange(rho0, &ilow, &iupp);
 
       /* Get dimension of partial system behind last oscillator ID (essential levels only) */
       dim_post = 1;
@@ -594,19 +636,22 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, const std
 
       if (k == j) {
         /* B_{kk} = E_{kk} -> set only one element at (k,k) */
-        elemID = getIndexReal(getVecID(k, k, dim_rho)); // real part in vectorized system
+        elemID = getVecID(k, k, dim_rho); // real part in vectorized system
         double val = 1.0;
-        if (ilow <= elemID && elemID < iupp) VecSetValues(rho0, 1, &elemID, &val, INSERT_VALUES);
+        if (ilow <= elemID && elemID < iupp) {
+          PetscInt id_global_x =  elemID + mpirank_petsc*localsize_u; 
+          VecSetValues(rho0, 1, &id_global_x, &val, INSERT_VALUES);
+        }
       } else {
       //   /* B_{kj} contains four non-zeros, two per row */
         PetscInt* rows = new PetscInt[4];
         PetscScalar* vals = new PetscScalar[4];
 
         /* Get storage index of Re(x) */
-        rows[0] = getIndexReal(getVecID(k, k, dim_rho)); // (k,k)
-        rows[1] = getIndexReal(getVecID(j, j, dim_rho)); // (j,j)
-        rows[2] = getIndexReal(getVecID(k, j, dim_rho)); // (k,j)
-        rows[3] = getIndexReal(getVecID(j, k, dim_rho)); // (j,k)
+        rows[0] = getVecID(k, k, dim_rho); // (k,k)
+        rows[1] = getVecID(j, j, dim_rho); // (j,j)
+        rows[2] = getVecID(k, j, dim_rho); // (k,j)
+        rows[3] = getVecID(j, k, dim_rho); // (j,k)
 
         if (k < j) { // B_{kj} = 1/2(E_kk + E_jj) + 1/2(E_kj + E_jk)
           vals[0] = 0.5;
@@ -614,20 +659,29 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, const std
           vals[2] = 0.5;
           vals[3] = 0.5;
           for (int i=0; i<4; i++) {
-            if (ilow <= rows[i] && rows[i] < iupp) VecSetValues(rho0, 1, &(rows[i]), &(vals[i]), INSERT_VALUES);
+            if (ilow <= rows[i] && rows[i] < iupp) {
+              PetscInt id_global_x =  rows[i]+ mpirank_petsc*localsize_u; 
+              VecSetValues(rho0, 1, &id_global_x, &(vals[i]), INSERT_VALUES);
+            }
           }
         } else {  // B_{kj} = 1/2(E_kk + E_jj) + i/2(E_jk - E_kj)
           vals[0] = 0.5;
           vals[1] = 0.5;
           for (int i=0; i<2; i++) {
-            if (ilow <= rows[i] && rows[i] < iupp) VecSetValues(rho0, 1, &(rows[i]), &(vals[i]), INSERT_VALUES);
+            if (ilow <= rows[i] && rows[i] < iupp) {
+              PetscInt id_global_x =  rows[i]+ mpirank_petsc*localsize_u; 
+              VecSetValues(rho0, 1, &id_global_x, &(vals[i]), INSERT_VALUES);
+            }
           }
           vals[2] = -0.5;
           vals[3] = 0.5;
-          rows[2] = getIndexImag(getVecID(k, j, dim_rho), dim); // (k,j)
-          rows[3] = getIndexImag(getVecID(j, k, dim_rho), dim); // (j,k)
+          rows[2] = getVecID(k, j, dim_rho); // (k,j)
+          rows[3] = getVecID(j, k, dim_rho); // (j,k)
           for (int i=2; i<4; i++) {
-            if (ilow <= rows[i] && rows[i] < iupp) VecSetValues(rho0, 1, &(rows[i]), &(vals[i]), INSERT_VALUES);
+            if (ilow <= rows[i] && rows[i] < iupp) {
+              PetscInt id_global_x =  rows[i]+ mpirank_petsc*localsize_u + localsize_u; 
+              VecSetValues(rho0, 1, &id_global_x, &(vals[i]), INSERT_VALUES);
+            }
           }
         }
         delete [] rows;
@@ -662,9 +716,7 @@ void OptimTarget::prepareTargetState(const Vec rho_t0){
 void OptimTarget::evalJ(const Vec state, double* J_re_ptr, double* J_im_ptr){
   double J_re = 0.0;
   double J_im = 0.0;
-  PetscInt diagID, diagID_re, diagID_im;
   double sum, rhoii, rhoii_re, rhoii_im, lambdai, norm;
-  PetscInt ilo, ihi;
   PetscInt dimsq;
 
   switch(objective_type) {
@@ -678,16 +730,22 @@ void OptimTarget::evalJ(const Vec state, double* J_re_ptr, double* J_im_ptr){
       } 
       else {  // target = e_me_m^\dagger ( or target = e_m for Schroedinger)
         assert(target_type == TargetType::PURE);
+
         // substract 1.0 from m-th diagonal element then take the vector norm 
-        if (lindbladtype != LindbladType::NONE) diagID = getIndexReal(getVecID(purestateID,purestateID,(PetscInt)sqrt(dim)));
-        else diagID = getIndexReal(purestateID);
-        VecGetOwnershipRange(state, &ilo, &ihi);
-        if (ilo <= diagID && diagID < ihi) VecSetValue(state, diagID, -1.0, ADD_VALUES);
+        PetscInt diagID = purestateID;
+        if (lindbladtype != LindbladType::NONE) diagID = getVecID(purestateID,purestateID,(PetscInt)sqrt(dim));
+        if (ilow <= diagID && diagID < iupp) {
+          PetscInt id_global_x = diagID + mpirank_petsc*localsize_u; 
+          VecSetValue(state, id_global_x, -1.0, ADD_VALUES);
+        }
         VecAssemblyBegin(state); VecAssemblyEnd(state);
         norm = 0.0;
         VecNorm(state, NORM_2, &norm);
         J_re = pow(norm, 2.0) / 2.0;
-        if (ilo <= diagID && diagID < ihi) VecSetValue(state, diagID, +1.0, ADD_VALUES); // restore original state!
+        if (ilow <= diagID && diagID < iupp) {
+          PetscInt id_global_x = diagID + mpirank_petsc*localsize_u; 
+          VecSetValue(state, id_global_x, +1.0, ADD_VALUES); // restore original state!
+        }
         VecAssemblyBegin(state); VecAssemblyEnd(state);
       }
       break;  // case Frobenius
@@ -706,24 +764,29 @@ void OptimTarget::evalJ(const Vec state, double* J_re_ptr, double* J_im_ptr){
         exit(1);
       }
 
+      dimsq = dim;   // Schroedinger solver: dim = N
       if (lindbladtype != LindbladType::NONE) dimsq = (PetscInt)sqrt(dim); // Lindblad solver: dim = N^2
-      else dimsq = dim;   // Schroedinger solver: dim = N
 
-      VecGetOwnershipRange(state, &ilo, &ihi);
       // iterate over diagonal elements 
       sum = 0.0;
       for (PetscInt i=0; i<dimsq; i++){
         if (lindbladtype != LindbladType::NONE) {
-          diagID = getIndexReal(getVecID(i,i,dimsq));
+          PetscInt diagID = getVecID(i,i,dimsq);
           rhoii = 0.0;
-          if (ilo <= diagID && diagID < ihi) VecGetValues(state, 1, &diagID, &rhoii);
+          if (ilow <= diagID && diagID < iupp) {
+            PetscInt id_global_x =  diagID + mpirank_petsc*localsize_u;
+            VecGetValues(state, 1, &id_global_x, &rhoii);
+          }
         } else  {
-          diagID_re = getIndexReal(i);
-          diagID_im = getIndexImag(i, dim);
+          PetscInt diagID = i;
           rhoii_re = 0.0;
           rhoii_im = 0.0;
-          if (ilo <= diagID_re && diagID_re < ihi) VecGetValues(state, 1, &diagID_re, &rhoii_re);
-          if (ilo <= diagID_im && diagID_im < ihi) VecGetValues(state, 1, &diagID_im, &rhoii_im);
+          if (ilow <= diagID && diagID < iupp) {
+            PetscInt id_global_x =  diagID + mpirank_petsc*localsize_u;
+            VecGetValues(state, 1, &id_global_x, &rhoii_re);
+            id_global_x += localsize_u;
+            VecGetValues(state, 1, &id_global_x, &rhoii_im);
+          }
           rhoii = pow(rhoii_re, 2.0) + pow(rhoii_im, 2.0);
         }
         lambdai = fabs(i - purestateID);
@@ -741,9 +804,7 @@ void OptimTarget::evalJ(const Vec state, double* J_re_ptr, double* J_im_ptr){
 
 
 void OptimTarget::evalJ_diff(const Vec state, Vec statebar, const double J_re_bar, const double J_im_bar){
-  PetscInt ilo, ihi;
   double lambdai, val, rhoii_re, rhoii_im;
-  PetscInt diagID, diagID_re, diagID_im, dimsq;
 
   switch (objective_type) {
 
@@ -756,10 +817,12 @@ void OptimTarget::evalJ_diff(const Vec state, Vec statebar, const double J_re_ba
         // Derivative of J = 1/2||x||^2 is xbar += x * Jbar, where x = rho(t) - E_mm
         VecAXPY(statebar, J_re_bar, state);
         // now substract 1.0*Jbar from m-th diagonal element
-        if (lindbladtype != LindbladType::NONE) diagID = getIndexReal(getVecID(purestateID,purestateID,(PetscInt)sqrt(dim)));
-        else diagID = getIndexReal(purestateID);
-        VecGetOwnershipRange(state, &ilo, &ihi);
-        if (ilo <= diagID && diagID < ihi) VecSetValue(statebar, diagID, -1.0*J_re_bar, ADD_VALUES);
+        PetscInt diagID = purestateID;
+        if (lindbladtype != LindbladType::NONE) diagID = getVecID(purestateID,purestateID,(PetscInt)sqrt(dim));
+        if (ilow <= diagID && diagID < iupp) {
+          PetscInt id_global_x = diagID + mpirank_petsc*localsize_u;
+          VecSetValue(statebar, id_global_x, -1.0*J_re_bar, ADD_VALUES);
+        }
       }
       break; // case JFROBENIUS
 
@@ -770,26 +833,31 @@ void OptimTarget::evalJ_diff(const Vec state, Vec statebar, const double J_re_ba
     case ObjectiveType::JMEASURE:
       assert(target_type == TargetType::PURE);         
 
+      PetscInt dimsq = dim;   // Schroedinger solver: dim = N
       if (lindbladtype != LindbladType::NONE) dimsq = (PetscInt)sqrt(dim); // Lindblad solver: dim = N^2
-      else dimsq = dim;   // Schroedinger solver: dim = N
 
       // iterate over diagonal elements 
       for (PetscInt i=0; i<dimsq; i++){
         lambdai = fabs(i - purestateID);
-        VecGetOwnershipRange(state, &ilo, &ihi);
         if (lindbladtype != LindbladType::NONE) {
-          diagID = getIndexReal(getVecID(i,i,dimsq));
+          PetscInt diagID = getVecID(i,i,dimsq);
           val = lambdai * J_re_bar;
-          if (ilo <= diagID && diagID < ihi) VecSetValue(statebar, diagID, val, ADD_VALUES);
+          if (ilow <= diagID && diagID < iupp) {
+            PetscInt id_global_x =  diagID + mpirank_petsc*localsize_u;
+            VecSetValue(statebar, id_global_x, val, ADD_VALUES);
+          }
         } else {
-          diagID_re = getIndexReal(i);
-          diagID_im = getIndexImag(i, dim);
+          PetscInt diagID = i;
           rhoii_re = 0.0;
           rhoii_im = 0.0;
-          if (ilo <= diagID_re && diagID_re < ihi) VecGetValues(state, 1, &diagID_re, &rhoii_re);
-          if (ilo <= diagID_im && diagID_im < ihi) VecGetValues(state, 1, &diagID_im, &rhoii_im);
-          if (ilo <= diagID_re && diagID_re < ihi) VecSetValue(statebar, diagID_re, 2.*J_re_bar*lambdai*rhoii_re, ADD_VALUES);
-          if (ilo <= diagID_im && diagID_im < ihi) VecSetValue(statebar, diagID_im, 2.*J_re_bar*lambdai*rhoii_im, ADD_VALUES);
+          if (ilow <= diagID && diagID < iupp) {
+            PetscInt id_global_x =  diagID + mpirank_petsc*localsize_u;
+            VecGetValues(state, 1, &id_global_x, &rhoii_re);
+            VecSetValue(statebar, id_global_x, 2.*J_re_bar*lambdai*rhoii_re, ADD_VALUES);
+            id_global_x += localsize_u;
+            VecGetValues(state, 1, &id_global_x, &rhoii_im);
+            VecSetValue(statebar, id_global_x, 2.*J_re_bar*lambdai*rhoii_im, ADD_VALUES);
+          }
         }
       }
     break;

--- a/src/oscillator.cpp
+++ b/src/oscillator.cpp
@@ -437,7 +437,7 @@ double Oscillator::expectedEnergy(const Vec x) {
     if (lindbladtype != LindbladType::NONE) idx_diag_re = getIndexReal(getVecID(i,i,dimmat));
     else {
       idx_diag_re = getIndexReal(i);
-      idx_diag_im = getIndexImag(i);
+      idx_diag_im = getIndexImag(i, dim/2);
     }
     
     double xdiag = 0.0;
@@ -490,7 +490,7 @@ void Oscillator::expectedEnergy_diff(const Vec x, Vec x_bar, const double obj_ba
       val = num_diag * xdiag * obj_bar;
       if (ilow <= idx_diag_re && idx_diag_re < iupp) VecSetValues(x_bar, 1, &idx_diag_re, &val, ADD_VALUES);
       // Imaginary part
-      idx_diag_im = getIndexImag(i);
+      idx_diag_im = getIndexImag(i, dim/2);
       xdiag = 0.0;
       if (ilow <= idx_diag_im && idx_diag_im < iupp) VecGetValues(x, 1, &idx_diag_im, &xdiag);
       val = - num_diag * xdiag * obj_bar; // TODO: Is this a minus or a plus?? 
@@ -533,7 +533,7 @@ void Oscillator::population(const Vec x, std::vector<double> &pop) {
           sum += val;
         } else {
           PetscInt diagID_re = getIndexReal(rhoID);
-          PetscInt diagID_im = getIndexImag(rhoID);
+          PetscInt diagID_im = getIndexImag(rhoID, dimN);
           val = 0.0;
           if (ilow <= diagID_re && diagID_re < iupp)  VecGetValues(x, 1, &diagID_re, &val);
           sum += val * val;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -258,8 +258,8 @@ void Output::writeTrajectoryDataFiles(int timestep, double time, const Vec state
         const PetscScalar *x;
         VecGetArrayRead(state, &x);
         for (int i=0; i<mastereq->getDim(); i++) {
-          fprintf(ufile, "%1.10e  ", x[getIndexReal(i)]);  
-          fprintf(vfile, "%1.10e  ", x[getIndexImag(i, mastereq->getDim())]);  
+          fprintf(ufile, "%1.10e  ", x[i]);  
+          fprintf(vfile, "%1.10e  ", x[i + mastereq->getDim()]);  
         }
         fprintf(ufile, "\n");
         fprintf(vfile, "\n");

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -259,7 +259,7 @@ void Output::writeTrajectoryDataFiles(int timestep, double time, const Vec state
         VecGetArrayRead(state, &x);
         for (int i=0; i<mastereq->getDim(); i++) {
           fprintf(ufile, "%1.10e  ", x[getIndexReal(i)]);  
-          fprintf(vfile, "%1.10e  ", x[getIndexImag(i)]);  
+          fprintf(vfile, "%1.10e  ", x[getIndexImag(i, mastereq->getDim())]);  
         }
         fprintf(ufile, "\n");
         fprintf(vfile, "\n");

--- a/src/timestepper.cpp
+++ b/src/timestepper.cpp
@@ -2,7 +2,6 @@
 #include "petscvec.h"
 
 TimeStepper::TimeStepper() {
-  dim = 0;
   mastereq = NULL;
   ntime = 0;
   total_time = 0.0;
@@ -16,7 +15,6 @@ TimeStepper::TimeStepper() {
 
 TimeStepper::TimeStepper(MasterEq* mastereq_, int ntime_, double total_time_, Output* output_, bool storeFWD_) : TimeStepper() {
   mastereq = mastereq_;
-  dim = 2*mastereq->getDim(); // will be either N^2 (Lindblad) or N (Schroedinger)
   ntime = ntime_;
   total_time = total_time_;
   output = output_;
@@ -256,7 +254,7 @@ double TimeStepper::penaltyIntegral(double time, const Vec x){
   double x_re, x_im;
 
   /* Get locally owned portion of x */
-  PetscInt localsize_u = dim / mpisize_petsc;
+  PetscInt localsize_u = mastereq->getDim() / mpisize_petsc;
   PetscInt ilow, iupp;
   VecGetOwnershipRange(x, &ilow, &iupp);
   ilow = ilow / 2;
@@ -305,7 +303,7 @@ void TimeStepper::penaltyIntegral_diff(double time, const Vec x, Vec xbar, doubl
   PetscInt dim_rho = mastereq->getDimRho();  // N
 
   /* Get locally owned portion of x */
-  PetscInt localsize_u = dim / mpisize_petsc;
+  PetscInt localsize_u = mastereq->getDim()/ mpisize_petsc;
   PetscInt ilow, iupp;
   VecGetOwnershipRange(x, &ilow, &iupp);
   ilow = ilow / 2;
@@ -351,10 +349,9 @@ void TimeStepper::penaltyIntegral_diff(double time, const Vec x, Vec xbar, doubl
 
 
 double TimeStepper::penaltyDpDm(Vec x, Vec xm1, Vec xm2){
-    PetscInt dim_rho = mastereq->getDimRho(); // N
 
     /* Get locally owned portion of x */
-    PetscInt localsize_u = dim / mpisize_petsc;
+    PetscInt localsize_u = mastereq->getDim() / mpisize_petsc;
     PetscInt ilow, iupp;
     VecGetOwnershipRange(x, &ilow, &iupp);
     ilow = ilow / 2;
@@ -389,10 +386,9 @@ double TimeStepper::penaltyDpDm(Vec x, Vec xm1, Vec xm2){
 
 
 void TimeStepper::penaltyDpDm_diff(int n, Vec xbar, double Jbar){
-    PetscInt dim_rho = mastereq->getDimRho(); // N
 
     /* Get locally owned portion of x */
-    PetscInt localsize_u = dim / mpisize_petsc;
+    PetscInt localsize_u = mastereq->getDim() / mpisize_petsc;
     PetscInt ilow, iupp;
     VecGetOwnershipRange(x, &ilow, &iupp);
     ilow = ilow / 2;

--- a/src/timestepper.cpp
+++ b/src/timestepper.cpp
@@ -267,10 +267,10 @@ double TimeStepper::penaltyIntegral(double time, const Vec x){
           // printf("%f: isGuard: %d / %d\n", time, i, dim_rho);
         if (mastereq->lindbladtype != LindbladType::NONE) {
           vecID_re = getIndexReal(getVecID(i,i,dim_rho));
-          vecID_im = getIndexImag(getVecID(i,i,dim_rho));
+          vecID_im = getIndexImag(getVecID(i,i,dim_rho), mastereq->getDim());
         } else {
           vecID_re = getIndexReal(i);
-          vecID_im = getIndexImag(i);
+          vecID_im = getIndexImag(i, mastereq->getDim());
         }
         x_re = 0.0; x_im = 0.0;
         if (ilow <= vecID_re && vecID_re < iupp) VecGetValues(x, 1, &vecID_re, &x_re);
@@ -313,10 +313,10 @@ void TimeStepper::penaltyIntegral_diff(double time, const Vec x, Vec xbar, doubl
       if ( isGuardLevel(i, mastereq->nlevels, mastereq->nessential) ) {
         if (mastereq->lindbladtype != LindbladType::NONE){ 
           vecID_re = getIndexReal(getVecID(i,i,dim_rho));
-          vecID_im = getIndexImag(getVecID(i,i,dim_rho));
+          vecID_im = getIndexImag(getVecID(i,i,dim_rho), mastereq->getDim());
         } else {
           vecID_re = getIndexReal(i);
-          vecID_im = getIndexImag(i);
+          vecID_im = getIndexImag(i, mastereq->getDim());
         }
         x_re = 0.0; x_im = 0.0;
         if (ilow <= vecID_re && vecID_re < iupp) VecGetValues(x, 1, &vecID_re, &x_re);
@@ -353,10 +353,10 @@ double TimeStepper::penaltyDpDm(Vec x, Vec xm1, Vec xm2){
     for (PetscInt i=0; i<dim_rho; i++) {
         if (mastereq->lindbladtype != LindbladType::NONE) { 
           vecID_re = getIndexReal(getVecID(i,i,dim_rho));
-          vecID_im = getIndexImag(getVecID(i,i,dim_rho));
+          vecID_im = getIndexImag(getVecID(i,i,dim_rho), mastereq->getDim());
         } else {
           vecID_re = getIndexReal(i);
-          vecID_im = getIndexImag(i);
+          vecID_im = getIndexImag(i, mastereq->getDim());
         }
 
         if (ilow <= vecID_re && vecID_re < iupp) tmp1 = xptr[vecID_re]*xptr[vecID_re] - 2.0*xm1ptr[vecID_re]*xm1ptr[vecID_re] + xm2ptr[vecID_re]*xm2ptr[vecID_re];
@@ -403,10 +403,10 @@ void TimeStepper::penaltyDpDm_diff(int n, Vec xbar, double Jbar){
     for (PetscInt i=0; i<dim_rho; i++) {
         if (mastereq->lindbladtype != LindbladType::NONE) { 
           vecID_re = getIndexReal(getVecID(i,i,dim_rho));
-          vecID_im = getIndexImag(getVecID(i,i,dim_rho));
+          vecID_im = getIndexImag(getVecID(i,i,dim_rho), mastereq->getDim());
         } else {
           vecID_re = getIndexReal(i);
-          vecID_im = getIndexImag(i);
+          vecID_im = getIndexImag(i, mastereq->getDim());
         }
 
         // first term

--- a/src/timestepper.cpp
+++ b/src/timestepper.cpp
@@ -9,6 +9,8 @@ TimeStepper::TimeStepper() {
   dt = 0.0;
   storeFWD = false;
   MPI_Comm_rank(MPI_COMM_WORLD, &mpirank_world);
+  MPI_Comm_rank(PETSC_COMM_WORLD, &mpirank_petsc);
+  MPI_Comm_size(PETSC_COMM_WORLD, &mpisize_petsc);
   writeTrajectoryDataFiles = false;
 }
 
@@ -34,7 +36,9 @@ TimeStepper::TimeStepper(MasterEq* mastereq_, int ntime_, double total_time_, Ou
     for (int n = 0; n <=ntime; n++) {
       Vec state;
       VecCreate(PETSC_COMM_WORLD, &state);
-      VecSetSizes(state, PETSC_DECIDE, dim);
+      PetscInt globalsize = 2 * mastereq->getDim();  // 2 for real and imaginary part
+      PetscInt localsize = globalsize / mpisize_petsc;  // Local vector per processor
+      VecSetSizes(state,localsize,globalsize);
       VecSetFromOptions(state);
       store_states.push_back(state);
     }
@@ -42,7 +46,10 @@ TimeStepper::TimeStepper(MasterEq* mastereq_, int ntime_, double total_time_, Ou
 
   /* Allocate auxiliary state vector */
   VecCreate(PETSC_COMM_WORLD, &x);
-  VecSetSizes(x, PETSC_DECIDE, dim);
+
+  PetscInt globalsize = 2 * mastereq->getDim(); 
+  PetscInt localsize = globalsize / mpisize_petsc;  // Local vector per processor
+  VecSetSizes(x,localsize,globalsize);
   VecSetFromOptions(x);
   VecZeroEntries(x);
   VecDuplicate(x, &xadj);
@@ -99,7 +106,9 @@ Vec TimeStepper::solveODE(int initid, Vec rho_t0){
     for (int i = 0; i < 2; i++) {
       Vec state;
       VecCreate(PETSC_COMM_WORLD, &state);
-      VecSetSizes(state, PETSC_DECIDE, dim);
+      PetscInt globalsize = 2 * mastereq->getDim(); 
+      PetscInt localsize = globalsize / mpisize_petsc;  // Local vector per processor
+      VecSetSizes(state,localsize,globalsize);
       VecSetFromOptions(state);
       dpdm_states.push_back(state);
     }
@@ -185,7 +194,9 @@ void TimeStepper::solveAdjointODE(Vec rho_t0_bar, Vec finalstate, double Jbar_pe
     for (int i = 0; i < 5; i++) {
       Vec state;
       VecCreate(PETSC_COMM_WORLD, &state);
-      VecSetSizes(state, PETSC_DECIDE, dim);
+      PetscInt globalsize = 2 * mastereq->getDim(); 
+      PetscInt localsize = globalsize / mpisize_petsc;  // Local vector per processor
+      VecSetSizes(state,localsize,globalsize);
       VecSetFromOptions(state);
       dpdm_states.push_back(state);
     }
@@ -243,7 +254,13 @@ double TimeStepper::penaltyIntegral(double time, const Vec x){
   double penalty = 0.0;
   PetscInt dim_rho = mastereq->getDimRho(); // N
   double x_re, x_im;
-  PetscInt vecID_re, vecID_im;
+
+  /* Get locally owned portion of x */
+  PetscInt localsize_u = dim / mpisize_petsc;
+  PetscInt ilow, iupp;
+  VecGetOwnershipRange(x, &ilow, &iupp);
+  ilow = ilow / 2;
+  iupp = ilow + localsize_u;
 
   /* weighted integral of the objective function */
   if (penalty_param > 1e-13) {
@@ -259,22 +276,20 @@ double TimeStepper::penaltyIntegral(double time, const Vec x){
   /* Add guard-level occupation to prevent leakage. A guard level is the LAST NON-ESSENTIAL energy level of an oscillator */
   if (addLeakagePrevent) {
     double leakage = 0.0;
-    PetscInt ilow, iupp;
-    VecGetOwnershipRange(x, &ilow, &iupp);
     /* Sum over all diagonal elements that correspond to a non-essential guard level. */
     for (PetscInt i=0; i<dim_rho; i++) {
       if ( isGuardLevel(i, mastereq->nlevels, mastereq->nessential) ) {
-          // printf("%f: isGuard: %d / %d\n", time, i, dim_rho);
-        if (mastereq->lindbladtype != LindbladType::NONE) {
-          vecID_re = getIndexReal(getVecID(i,i,dim_rho));
-          vecID_im = getIndexImag(getVecID(i,i,dim_rho), mastereq->getDim());
-        } else {
-          vecID_re = getIndexReal(i);
-          vecID_im = getIndexImag(i, mastereq->getDim());
+        // vectorize if lindblad
+        PetscInt vecID = i;
+        if (mastereq->lindbladtype != LindbladType::NONE) vecID = getVecID(i,i,dim_rho);
+        x_re = 0.0; 
+        x_im = 0.0;
+        if (ilow <= vecID && vecID < iupp) {
+          PetscInt id_global_x = vecID + mpirank_petsc*localsize_u; 
+          VecGetValues(x, 1, &id_global_x, &x_re);
+          id_global_x += localsize_u; 
+          VecGetValues(x, 1, &id_global_x, &x_im); 
         }
-        x_re = 0.0; x_im = 0.0;
-        if (ilow <= vecID_re && vecID_re < iupp) VecGetValues(x, 1, &vecID_re, &x_re);
-        if (ilow <= vecID_im && vecID_im < iupp) VecGetValues(x, 1, &vecID_im, &x_im); 
         leakage += (x_re * x_re + x_im * x_im) / (dt*ntime);
       }
     }
@@ -288,7 +303,13 @@ double TimeStepper::penaltyIntegral(double time, const Vec x){
 
 void TimeStepper::penaltyIntegral_diff(double time, const Vec x, Vec xbar, double penaltybar){
   PetscInt dim_rho = mastereq->getDimRho();  // N
-  PetscInt vecID_re, vecID_im;
+
+  /* Get locally owned portion of x */
+  PetscInt localsize_u = dim / mpisize_petsc;
+  PetscInt ilow, iupp;
+  VecGetOwnershipRange(x, &ilow, &iupp);
+  ilow = ilow / 2;
+  iupp = ilow + localsize_u;
 
   /* Derivative of weighted integral of the objective function */
   if (penalty_param > 1e-13){
@@ -306,24 +327,21 @@ void TimeStepper::penaltyIntegral_diff(double time, const Vec x, Vec xbar, doubl
 
   /* If gate optimization: Derivative of adding guard-level occupation */
   if (addLeakagePrevent) {
-    PetscInt ilow, iupp;
-    VecGetOwnershipRange(x, &ilow, &iupp);
     double x_re, x_im;
     for (PetscInt i=0; i<dim_rho; i++) {
       if ( isGuardLevel(i, mastereq->nlevels, mastereq->nessential) ) {
-        if (mastereq->lindbladtype != LindbladType::NONE){ 
-          vecID_re = getIndexReal(getVecID(i,i,dim_rho));
-          vecID_im = getIndexImag(getVecID(i,i,dim_rho), mastereq->getDim());
-        } else {
-          vecID_re = getIndexReal(i);
-          vecID_im = getIndexImag(i, mastereq->getDim());
+        PetscInt  vecID = i;
+        if (mastereq->lindbladtype != LindbladType::NONE) vecID = getVecID(i,i,dim_rho);
+        x_re = 0.0; 
+        x_im = 0.0;
+        if (ilow <= vecID && vecID < iupp) {
+          PetscInt id_global_x = vecID + mpirank_petsc*localsize_u; 
+          VecGetValues(x, 1, &id_global_x, &x_re);
+          VecSetValue(xbar, id_global_x, 2.*x_re*penaltybar/ntime, ADD_VALUES);
+          id_global_x += localsize_u; 
+          VecGetValues(x, 1, &id_global_x, &x_im);
+          VecSetValue(xbar, id_global_x, 2.*x_im*penaltybar/ntime, ADD_VALUES);
         }
-        x_re = 0.0; x_im = 0.0;
-        if (ilow <= vecID_re && vecID_re < iupp) VecGetValues(x, 1, &vecID_re, &x_re);
-        if (ilow <= vecID_im && vecID_im < iupp) VecGetValues(x, 1, &vecID_im, &x_im);
-        // Derivative: 2 * rho(i,i) * weights * penalbar * dt
-        if (ilow <= vecID_re && vecID_re < iupp) VecSetValue(xbar, vecID_re, 2.*x_re*penaltybar/ntime, ADD_VALUES);
-        if (ilow <= vecID_im && vecID_im < iupp) VecSetValue(xbar, vecID_im, 2.*x_im*penaltybar/ntime, ADD_VALUES);
       }
     }
     VecAssemblyBegin(xbar);
@@ -334,33 +352,31 @@ void TimeStepper::penaltyIntegral_diff(double time, const Vec x, Vec xbar, doubl
 
 double TimeStepper::penaltyDpDm(Vec x, Vec xm1, Vec xm2){
     PetscInt dim_rho = mastereq->getDimRho(); // N
-    PetscInt vecID_re, vecID_im;
 
-    double tmp1, tmp2;
+    /* Get locally owned portion of x */
+    PetscInt localsize_u = dim / mpisize_petsc;
+    PetscInt ilow, iupp;
+    VecGetOwnershipRange(x, &ilow, &iupp);
+    ilow = ilow / 2;
+    iupp = ilow + localsize_u;
 
+    // Get local data pointers
     const PetscScalar *xptr, *xm1ptr, *xm2ptr;
     VecGetArrayRead(x, &xptr);
     VecGetArrayRead(xm1, &xm1ptr);
     VecGetArrayRead(xm2, &xm2ptr);
      
-    PetscInt ilow, iupp;
-
     /* precompute 1/dt^4 */
     double dtinv = 1.0 / (dt*dt*dt*dt);
 
     double dpdm = 0.0;
-    VecGetOwnershipRange(x, &ilow, &iupp);
-    for (PetscInt i=0; i<dim_rho; i++) {
-        if (mastereq->lindbladtype != LindbladType::NONE) { 
-          vecID_re = getIndexReal(getVecID(i,i,dim_rho));
-          vecID_im = getIndexImag(getVecID(i,i,dim_rho), mastereq->getDim());
-        } else {
-          vecID_re = getIndexReal(i);
-          vecID_im = getIndexImag(i, mastereq->getDim());
-        }
+    for (PetscInt i=0; i<localsize_u; i++) {
+        PetscInt vecID_re = i;
+        PetscInt vecID_im = i + localsize_u;
 
-        if (ilow <= vecID_re && vecID_re < iupp) tmp1 = xptr[vecID_re]*xptr[vecID_re] - 2.0*xm1ptr[vecID_re]*xm1ptr[vecID_re] + xm2ptr[vecID_re]*xm2ptr[vecID_re];
-        if (ilow <= vecID_im && vecID_im < iupp) tmp2 = xptr[vecID_im]*xptr[vecID_im] - 2.0*xm1ptr[vecID_im]*xm1ptr[vecID_im] + xm2ptr[vecID_im]*xm2ptr[vecID_im];
+        double tmp1 = xptr[vecID_re]*xptr[vecID_re] - 2.0*xm1ptr[vecID_re]*xm1ptr[vecID_re] + xm2ptr[vecID_re]*xm2ptr[vecID_re];
+        double tmp2 = xptr[vecID_im]*xptr[vecID_im] - 2.0*xm1ptr[vecID_im]*xm1ptr[vecID_im] + xm2ptr[vecID_im]*xm2ptr[vecID_im];
+
         dpdm += dtinv * (tmp1 + tmp2)*(tmp1 + tmp2);
     }
 
@@ -374,7 +390,13 @@ double TimeStepper::penaltyDpDm(Vec x, Vec xm1, Vec xm2){
 
 void TimeStepper::penaltyDpDm_diff(int n, Vec xbar, double Jbar){
     PetscInt dim_rho = mastereq->getDimRho(); // N
-    PetscInt vecID_re, vecID_im;
+
+    /* Get locally owned portion of x */
+    PetscInt localsize_u = dim / mpisize_petsc;
+    PetscInt ilow, iupp;
+    VecGetOwnershipRange(x, &ilow, &iupp);
+    ilow = ilow / 2;
+    iupp = ilow + localsize_u;
 
     const PetscScalar *xptr, *xm1ptr, *xm2ptr, *xp1ptr, *xp2ptr;
     Vec x, xm1, xm2, xp1, xp2;
@@ -393,27 +415,17 @@ void TimeStepper::penaltyDpDm_diff(int n, Vec xbar, double Jbar){
     if (n < ntime)    VecGetArrayRead(xp1, &xp1ptr);
     if (n < ntime-1)  VecGetArrayRead(xp2, &xp2ptr);
 
-     
-    PetscInt ilow, iupp;
-
     /* precompute 1/dt^4 */
     double dtinv = 1.0 / (dt*dt*dt*dt);
 
-    VecGetOwnershipRange(x, &ilow, &iupp);
-    for (PetscInt i=0; i<dim_rho; i++) {
-        if (mastereq->lindbladtype != LindbladType::NONE) { 
-          vecID_re = getIndexReal(getVecID(i,i,dim_rho));
-          vecID_im = getIndexImag(getVecID(i,i,dim_rho), mastereq->getDim());
-        } else {
-          vecID_re = getIndexReal(i);
-          vecID_im = getIndexImag(i, mastereq->getDim());
-        }
+    for (PetscInt i=0; i<localsize_u; i++) {
+        PetscInt vecID_re = i;
+        PetscInt vecID_im = i + localsize_u;
 
         // first term
         if (n > 1) {
           // if (i==0) printf("DPDM BWD, update %d from on first f(%d %d %d) \n", n, n-2, n-1, n);
 
-          if (ilow <= vecID_re && vecID_re < iupp) { // should be same as im. 
             double tmp1 = xm2ptr[vecID_re]*xm2ptr[vecID_re] - 2.0*xm1ptr[vecID_re]*xm1ptr[vecID_re] + xptr[vecID_re]*xptr[vecID_re];
             double tmp2 = xm2ptr[vecID_im]*xm2ptr[vecID_im] - 2.0*xm1ptr[vecID_im]*xm1ptr[vecID_im] + xptr[vecID_im]*xptr[vecID_im];
             double pop = tmp1+tmp2;
@@ -421,13 +433,11 @@ void TimeStepper::penaltyDpDm_diff(int n, Vec xbar, double Jbar){
             double dpdphi_im = 2.0*xptr[vecID_im];
             VecSetValue(xbar,vecID_re,  2.0 * pop * dpdphi_re * dtinv * Jbar, ADD_VALUES);
             VecSetValue(xbar,vecID_im,  2.0 * pop * dpdphi_im * dtinv * Jbar, ADD_VALUES);
-          }
         }
 
         // center term
         if (n > 0 && n < ntime) {
             // if (i==0) printf("DPDM BWD, update %d from on second f(%d %d %d) \n", n, n-1, n, n+1);
-            if (ilow <= vecID_re && vecID_re < iupp) {
               double tmp1 = xm1ptr[vecID_re]*xm1ptr[vecID_re] - 2.0*xptr[vecID_re]*xptr[vecID_re] + xp1ptr[vecID_re]*xp1ptr[vecID_re];
               double tmp2 = xm1ptr[vecID_im]*xm1ptr[vecID_im] - 2.0*xptr[vecID_im]*xptr[vecID_im] + xp1ptr[vecID_im]*xp1ptr[vecID_im];
               double pop = tmp1 + tmp2;
@@ -435,13 +445,11 @@ void TimeStepper::penaltyDpDm_diff(int n, Vec xbar, double Jbar){
               double dpdphi_im = 2.0*xptr[vecID_im];
               VecSetValue(xbar, vecID_re, - 4.0 * pop * dpdphi_re * dtinv * Jbar, ADD_VALUES);
               VecSetValue(xbar, vecID_im, - 4.0 * pop * dpdphi_im * dtinv * Jbar, ADD_VALUES);
-            }
         }
         
         // last term 
         if (n < ntime-1) {
             // if (i==0) printf("DPDM BWD, update %d from on third f(%d %d %d) \n", n, n, n+1, n+2);
-            if (ilow <= vecID_re && vecID_re < iupp) {
               double tmp1 = xptr[vecID_re]*xptr[vecID_re] - 2.0*xp1ptr[vecID_re]*xp1ptr[vecID_re] + xp2ptr[vecID_re]*xp2ptr[vecID_re];
               double tmp2 = xptr[vecID_im]*xptr[vecID_im] - 2.0*xp1ptr[vecID_im]*xp1ptr[vecID_im] + xp2ptr[vecID_im]*xp2ptr[vecID_im];
               double pop = tmp1 + tmp2;
@@ -449,7 +457,6 @@ void TimeStepper::penaltyDpDm_diff(int n, Vec xbar, double Jbar){
               double dpdphi_im = 2.0*xptr[vecID_im];
               VecSetValue(xbar, vecID_re, 2.0* pop * dpdphi_re * dtinv * Jbar, ADD_VALUES);
               VecSetValue(xbar, vecID_im, 2.0* pop * dpdphi_im * dtinv * Jbar, ADD_VALUES);
-            }
         }
     }
 
@@ -779,15 +786,17 @@ CompositionalImplMidpoint::CompositionalImplMidpoint(int order_, MasterEq* maste
   if (mpirank_world == 0) printf("Timestepper: Compositional Impl. Midpoint, order %d, %lu stages\n", order, gamma.size());
 
   // Allocate storage of stages for backward process 
+  PetscInt globalsize = 2 * mastereq->getDim(); 
+  PetscInt localsize = globalsize / mpisize_petsc;  // Local vector per processor
   for (size_t i = 0; i <gamma.size(); i++) {
     Vec state;
     VecCreate(PETSC_COMM_WORLD, &state);
-    VecSetSizes(state, PETSC_DECIDE, dim);
+    VecSetSizes(state,localsize,globalsize);
     VecSetFromOptions(state);
     x_stage.push_back(state);
   }
   VecCreate(PETSC_COMM_WORLD, &aux);
-  VecSetSizes(aux, PETSC_DECIDE, dim);
+  VecSetSizes(aux,localsize,globalsize);
   VecSetFromOptions(aux);
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -69,11 +69,13 @@ double getRampFactor_diff(const double time, const double tstart, const double t
 }
 
 PetscInt getIndexReal(const PetscInt i) {
-  return 2*i;
+  // return 2*i; // colocated
+  return i;     // blocked
 }
 
-PetscInt getIndexImag(const PetscInt i) {
-  return 2*i + 1;
+PetscInt getIndexImag(const PetscInt i, const PetscInt size) {
+  // return 2*i + 1; // colocated
+  return i + size;  // blocked
 }
 
 PetscInt getVecID(const PetscInt row, const PetscInt col, const PetscInt dim){

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -68,15 +68,6 @@ double getRampFactor_diff(const double time, const double tstart, const double t
     return dramp_dtstop;
 }
 
-PetscInt getIndexReal(const PetscInt i) {
-  // return 2*i; // colocated
-  return i;     // blocked
-}
-
-PetscInt getIndexImag(const PetscInt i, const PetscInt size) {
-  // return 2*i + 1; // colocated
-  return i + size;  // blocked
-}
 
 PetscInt getVecID(const PetscInt row, const PetscInt col, const PetscInt dim){
   return row + col * dim;  
@@ -372,8 +363,8 @@ PetscErrorCode StateIsHermitian(Vec x, PetscReal tol, PetscBool *flag) {
   IS isu, isv;
 
   PetscInt dimis = dim;
-  ierr = ISCreateStride(PETSC_COMM_WORLD, dimis, 0, 2, &isu); CHKERRQ(ierr);
-  ierr = ISCreateStride(PETSC_COMM_WORLD, dimis, 1, 2, &isv); CHKERRQ(ierr);
+  ierr = ISCreateStride(PETSC_COMM_WORLD, dimis, 0, 1, &isu); CHKERRQ(ierr);
+  ierr = ISCreateStride(PETSC_COMM_WORLD, dimis, dimis, 1, &isv); CHKERRQ(ierr);
   ierr = VecGetSubVector(x, isu, &u); CHKERRQ(ierr);
   ierr = VecGetSubVector(x, isv, &v); CHKERRQ(ierr);
 
@@ -421,8 +412,8 @@ PetscErrorCode StateHasTrace1(Vec x, PetscReal tol, PetscBool *flag) {
   PetscInt dimis = dim/2;
   Vec u, v;
   IS isu, isv;
-  ierr = ISCreateStride(PETSC_COMM_WORLD, dimis, 0, 2, &isu); CHKERRQ(ierr);
-  ierr = ISCreateStride(PETSC_COMM_WORLD, dimis, 1, 2, &isv); CHKERRQ(ierr);
+  ierr = ISCreateStride(PETSC_COMM_WORLD, dimis, 0, 1, &isu); CHKERRQ(ierr);
+  ierr = ISCreateStride(PETSC_COMM_WORLD, dimis, dimis, 1, &isv); CHKERRQ(ierr);
   ierr = VecGetSubVector(x, isu, &u); CHKERRQ(ierr);
   ierr = VecGetSubVector(x, isv, &v); CHKERRQ(ierr);
 


### PR DESCRIPTION
Rather than storing the real and imaginary parts in colocated way (staggered u_1, v_1, u_2, v_2 ...,), this changes the storage to a blocked one that lists first all real and then all imaginary parts (u_1, u_2, ..., v_1, v_2, ...). This speeds up matrix multiplications which need to grab the subvectors u and v. 