### PR TITLE
Add warnings checks to GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,6 @@ jobs:
 
     - name: Configure Spack
       run: |
-        spack -e .spack_env mirror set binary_mirror --unsigned
         spack mirror add --type binary --unsigned --oci-username GITHUB_USER --oci-password-variable GITHUB_TOKEN local-buildcache oci://ghcr.io/LLNL/quandary-spack-buildcache
 
     - name: Install with strict warnings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install with strict warnings
       run: |
         spack -e .spack_env rm quandary
-        spack -e .spack_env add "quandary@develop build_type=Debug cxxflags=\"-Werror -Wall -Wextra -Wpedantic\" %${{ matrix.compiler }} ^openmpi"
+        spack -e .spack_env add "quandary@develop build_type=Debug %${{ matrix.compiler }} ^openmpi"
         spack -e .spack_env install -v --use-buildcache package:never
 
     - name: Push packages and update index

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Build Check
+
+on:
+  pull_request:
+    branches: ['main']
+  push:
+    branches: ['main']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  strict-compile:
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Set up Spack
+      uses: spack/setup-spack@v2
+
+    - name: Configure Spack
+      run: |
+        spack -e .spack_env mirror set binary_mirror --unsigned
+        spack mirror add --type binary --unsigned --oci-username GITHUB_USER --oci-password-variable GITHUB_TOKEN local-buildcache oci://ghcr.io/LLNL/quandary-spack-buildcache
+
+    - name: Install with strict warnings
+      run: |
+        spack -e .spack_env rm quandary
+        spack -e .spack_env add "quandary@develop build_type=Debug cxxflags=\"-Werror -Wall -Wextra -Wpedantic\" %${{ matrix.compiler }} ^openmpi"
+        spack -e .spack_env install -v --use-buildcache package:never
+
+    - name: Push packages and update index
+      env:
+        GITHUB_USER: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DOCKER_DEFAULT_PLATFORM: linux/amd64
+      run: |
+        spack -e .spack_env buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+      if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install with strict warnings
       run: |
         spack -e .spack_env rm quandary
-        spack -e .spack_env add "quandary@develop build_type=Debug %${{ matrix.compiler }} ^openmpi"
+        spack -e .spack_env add "quandary@develop +werror %${{ matrix.compiler }} ^openmpi"
         spack -e .spack_env install -v --use-buildcache package:never
 
     - name: Push packages and update index

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,7 +1,10 @@
-name: Deploy Doxygen Documentation to GitHub Pages
+name: Doxygen Documentation
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
     branches:
       - main
 
@@ -13,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
-    name: Build and Deploy Doxygen Docs
+  build:
+    name: Build Doxygen Documentation
     runs-on: ubuntu-latest
 
     steps:
@@ -33,7 +36,8 @@ jobs:
         cmake -DENABLE_MPI=OFF -DBUILD_QUANDARY=OFF ..
         cmake --build . --target quandary_doxygen
 
-    - name: Deploy to GitHub Pages
+    - name: Deploy to GitHub Pages on main branch
+      if: github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
 
     - name: Configure Spack
       run: |
-        spack -e .spack_env mirror set binary_mirror --unsigned
         spack mirror add --type binary --unsigned --oci-username GITHUB_USER --oci-password-variable GITHUB_TOKEN local-buildcache oci://ghcr.io/LLNL/quandary-spack-buildcache
 
     - name: Add only use GCC on macOS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,9 @@
 name: Build and Test
 
 on:
-  pull_request:
-    branches: ['main']
-  push:
-    branches: ['main']
+  workflow_run:
+    workflows: ["Build Check"]
+    types: [completed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,6 +11,8 @@ concurrency:
 
 jobs:
   build-and-test:
+    # Only run if build workflow succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
         os: [macos-latest, ubuntu-24.04]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,10 @@
 name: Build and Test
 
 on:
-  workflow_run:
-    workflows: ["Build Check"]
-    types: [completed]
+  pull_request:
+    branches: ['main']
+  push:
+    branches: ['main']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,8 +12,6 @@ concurrency:
 
 jobs:
   build-and-test:
-    # Only run if build workflow succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
         os: [macos-latest, ubuntu-24.04]

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -10,3 +10,13 @@
   script:
     - !reference [.reproducer_vars, script]
 
+########################
+# Overridden shared jobs
+########################
+
+# TODO: Temporarily need to force ^pkgconf instead of pkg-config (remove this when fixed in radiuss-spack-configs)
+# Force use of petsc >= 3.23 as 3.22 doesn't seem to work with rocm 6.4.1
+rocmcc_6_4_1_hip:
+  variables:
+    SPEC: "${PROJECT_TIOGA_VARIANTS} +rocm amdgpu_target=gfx90a %rocmcc@=6.4.1 ^hip@6.4.1 ${PROJECT_TIOGA_DEPS} ^petsc@3.23: ^pkgconf"
+  extends: .job_on_tioga

--- a/.spack_env/spack.yaml
+++ b/.spack_env/spack.yaml
@@ -13,5 +13,3 @@ spack:
     quandary:
       path: ../
       spec: quandary@=develop
-  mirrors:
-    binary_mirror: https://binaries.spack.io/develop

--- a/.spack_env/spack.yaml
+++ b/.spack_env/spack.yaml
@@ -13,3 +13,6 @@ spack:
     quandary:
       path: ../
       spec: quandary@=develop
+  config:
+    flags:
+      keep_werror: all

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,6 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose build type" FORCE)
 endif()
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(ENABLE_WARNINGS_AS_ERRORS ON CACHE BOOL "Enable warnings as errors")
-endif()
-
 set(BLT_CXX_STD "c++14" CACHE STRING "Version of C++ standard")
 set(CMAKE_CXX_STANDARD 14)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose build type" FORCE)
 endif()
 
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(ENABLE_WARNINGS_AS_ERRORS ON CACHE BOOL "Enable warnings as errors")
+endif()
+
 set(BLT_CXX_STD "c++14" CACHE STRING "Version of C++ standard")
 set(CMAKE_CXX_STANDARD 14)
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,7 @@ Spack can be used to install Quandary, including the required dependency on Pets
     spack env activate .spack_env/
     ```
 
-4. Trust Spack's binary mirror so we can speed up the installation process (optional):
-    ```
-    spack buildcache keys --install --trust
-    ```
-5. Finally, to install the necessary dependencies and build Quandary run:
+4. Finally, to install the necessary dependencies and build Quandary run:
     ```
     spack install
     ```

--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -7,3 +7,4 @@ USE_MATHJAX            = YES
 EXTRACT_ALL            = YES
 SHOW_FILES             = YES
 QUIET                  = YES
+WARN_AS_ERROR = FAIL_ON_WARNINGS_PRINT

--- a/include/mastereq.hpp
+++ b/include/mastereq.hpp
@@ -48,7 +48,7 @@ typedef struct {
  * Each function returns y = RHS*x. Matrix-free versions as well as sparse-matrix versions are implemented. Those 
  * functions will be passed to PETSc's MatMult operations to realize a Matrix-Vector Multiplication of the RHS with 
  * a state vector, such that one can call PETSc's MatMult(RHS, x, y) for the RHS. 
- * Note: The RHS matrix must be assembled before usage, see @ref assemble_RHS. 
+ * Note: The RHS matrix must be assembled before usage, see @ref MasterEq::assemble_RHS.
  */
 int applyRHS_matfree_1Osc(Mat RHS, Vec x, Vec y); ///< Matrix-free MatMult for 1 oscillator
 int applyRHS_matfree_transpose_1Osc(Mat RHS, Vec x, Vec y); ///< Transpose matrix-free MatMult for 1 oscillator

--- a/include/output.hpp
+++ b/include/output.hpp
@@ -65,7 +65,7 @@ class Output{
      * @brief Writes optimization progress to history file.
      *
      * Called at every optimization iteration to log convergence data. 
-     * Optimization history will be written to <datadir>/optim_history.dat.
+     * Optimization history will be written to `<datadir>/optim_history.dat`.
      *
      * @param optim_iter Current optimization iteration
      * @param objective Total objective function value
@@ -85,8 +85,8 @@ class Output{
      * @brief Writes current control pulses per oscillator and control parameters.
      *
      * Called every optim_monitor_freq optimization iterations. 
-     * Control pulses are written to <datadir>/control<ioscillator>.dat
-     * Control parameters are written to <datadir>/params.dat
+     * Control pulses are written to `<datadir>/control<ioscillator>.dat`
+     * Control parameters are written to `<datadir>/params.dat`
      *
      * @param params Current parameter vector
      * @param mastereq Pointer to master equation solver
@@ -98,7 +98,7 @@ class Output{
     /**
      * @brief Writes gradient vector for debugging adjoint calculations.
      * 
-     * Gradient is written to <datadir>/grad.dat
+     * Gradient is written to `<datadir>/grad.dat`
      *
      * @param grad Gradient vector to output
      */

--- a/src/mastereq.cpp
+++ b/src/mastereq.cpp
@@ -107,7 +107,7 @@ MasterEq::MasterEq(const std::vector<int>& nlevels_, const std::vector<int>& nes
       addT2 = true;
       break;
     default:
-      printf("ERROR! Wrong lindblad type: %d\n", lindbladtype);
+      printf("ERROR! Wrong lindblad type: %d\n", static_cast<int>(lindbladtype));
       exit(1);
   }
 

--- a/src/optimproblem.cpp
+++ b/src/optimproblem.cpp
@@ -83,12 +83,10 @@ OptimProblem::OptimProblem(Config config, TimeStepper* timestepper_, MPI_Comm co
   for (size_t i=0; i<ninit; i++) scaleweights += obj_weights[i];
   for (size_t i=0; i<ninit; i++) obj_weights[i] = obj_weights[i] / scaleweights;
   // Distribute over mpi_init processes 
-  double sendbuf[obj_weights.size()];
-  double recvbuf[obj_weights.size()];
-  for (size_t i = 0; i < obj_weights.size(); i++) sendbuf[i] = obj_weights[i];
-  for (size_t i = 0; i < obj_weights.size(); i++) recvbuf[i] = obj_weights[i];
+  std::vector<double> sendbuf = obj_weights;
+  std::vector<double> recvbuf = obj_weights;
   int nscatter = ninit_local;
-  MPI_Scatter(sendbuf, nscatter, MPI_DOUBLE, recvbuf, nscatter,  MPI_DOUBLE, 0, comm_init);
+  MPI_Scatter(sendbuf.data(), nscatter, MPI_DOUBLE, recvbuf.data(), nscatter,  MPI_DOUBLE, 0, comm_init);
   for (int i = 0; i < nscatter; i++) obj_weights[i] = recvbuf[i];
   for (size_t i=nscatter; i < obj_weights.size(); i++) obj_weights[i] = 0.0;
 

--- a/src/optimtarget.cpp
+++ b/src/optimtarget.cpp
@@ -690,7 +690,7 @@ int OptimTarget::prepareInitialState(const int iinit, const int ninit, const std
       break;
 
     default:
-      printf("ERROR! Wrong initial condition type: %d\n This should never happen!\n", initcond_type);
+      printf("ERROR! Wrong initial condition type: %d\n This should never happen!\n", static_cast<int>(initcond_type));
       exit(1);
   }
 

--- a/src/timestepper.cpp
+++ b/src/timestepper.cpp
@@ -372,7 +372,7 @@ double TimeStepper::penaltyDpDm(Vec x, Vec xm1, Vec xm2){
 void TimeStepper::penaltyDpDm_diff(int n, Vec xbar, double Jbar){
 
     const PetscScalar *xptr, *xm1ptr, *xm2ptr, *xp1ptr, *xp2ptr;
-    Vec x, xm1, xm2, xp1, xp2;
+    Vec x = nullptr, xm1 = nullptr, xm2 = nullptr, xp1 = nullptr, xp2 = nullptr;
 
     int k = ntime - n;
     int idx = 4-(k+4)%5;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -498,7 +498,12 @@ int read_vector(const char *filename, double *var, int dim, bool quietmode, int 
     /* Scip first <skiplines> lines */
     char buffer[51]; // need one extra element because fscanf adds a '\0' at the end
     for (int ix = 0; ix < skiplines; ix++) {
-      fscanf(file, "%50[^\n]%*c", buffer); // // NOTE: &buffer[50] is a pointer to buffer[50] (i.e. its last element)
+      int ret = fscanf(file, "%50[^\n]%*c", buffer); // // NOTE: &buffer[50] is a pointer to buffer[50] (i.e. its last element)
+      if (ret == EOF) {
+        printf("ERROR: EOF reached while skipping lines in file %s.\n", filename);
+        fclose(file);
+        return success;
+      }
       // printf("Skipping %d lines: %s \n:", skiplines, buffer);
     }
 


### PR DESCRIPTION
This PR:
- Use spack variant +werror to build with flag `-Werror` (fails if there are compiler warnings) in a GitHub CI job. By default this flag is not used
- Adds build workflow that builds quandary with gcc and clang with +werror
- Updates doxygen workflow to run on PRs and fail if there are documentation warnings
- Fixes doxygen warnings
- Fixes compiler warnings

A few slightly unrelated changes:
-  Removes binary cache from spack.yaml which seems to slow down spack
- Updates radiuss-spack-configs module (needed to get the latest quandary spack package with werror variant)
- Fixes tioga CI for updated version of radiuss-spack-configs