### PR TITLE
Change the default gate rotation to be zero.

### DIFF
--- a/config_template.cfg
+++ b/config_template.cfg
@@ -77,7 +77,7 @@ optim_target = gate, cnot
 #optim_target = gate, file, /path/to/target_gate.dat
 #optim_target = pure, 0, 0
 #optim_target = file, /path/to/target_state.dat
-// Frequency of rotation of the target gate, for each oscillator (GHz). Default: Use the computational rotating frame (rotfreq).
+// Frequency of rotation of the target gate, for each oscillator (GHz). Default: 0.0
 # gate_rot_freq = 0.0,0.0
 // Objective function measure
 optim_objective = Jtrace

--- a/src/optimtarget.cpp
+++ b/src/optimtarget.cpp
@@ -210,7 +210,7 @@ OptimTarget::OptimTarget(std::vector<std::string> target_str, const std::string&
       if (read_gate_rot[0] < 1e20) // the config option exists, use it, else use mastereq rotationnal frequency as default
         gate_rot_freq[iosc] = read_gate_rot[iosc];
       else
-        gate_rot_freq[iosc] = mastereq->getOscillator(iosc)->getRotFreq();
+        gate_rot_freq[iosc] = 0.0;
     }
     /* Initialize the targetgate */
     targetgate = initTargetGate(target_str, mastereq->nlevels, mastereq->nessential, total_time, lindbladtype, gate_rot_freq, quietmode);

--- a/tests/regression/cnot/cnot.cfg
+++ b/tests/regression/cnot/cnot.cfg
@@ -32,6 +32,7 @@ linearsolver_type = gmres
 linearsolver_maxiter = 20
 timestepper = IMR
 optim_target = gate,cnot
+gate_rot_freq = 4.10595,4.81526
 optim_objective = Jtrace
 optim_weights = 1.0
 optim_regul = 1e-05


### PR DESCRIPTION
This changes the default setting for the gate_rot_freq configuration in the C++ code to be zero. 
This is now consistent with the default setting in the python interface.