### PR TITLE
Replace ruby with dane in CI jobs

### DIFF
--- a/.ci-scripts/build_and_test.sh
+++ b/.ci-scripts/build_and_test.sh
@@ -199,7 +199,7 @@ then
     # We set the MPI tests command to allow overlapping.
     # Shared allocation: Allows build_and_test.sh to run within a sub-allocation (see CI config).
     cmake_options=""
-    if [[ "${truehostname}" == "ruby" || "${truehostname}" == "poodle" ]]
+    if [[ "${truehostname}" == "dane" ]]
     then
         cmake_options="-DBLT_MPI_COMMAND_APPEND:STRING=--overlap"
     fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,7 +74,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs-and-variables.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: 'v2024.07.0'
+        ref: 'v2025.06.0'
         file: 'pipelines/${CI_MACHINE}.yml'
       - artifact: '${CI_MACHINE}-jobs.yml'
         job: 'generate-job-lists'
@@ -88,9 +88,9 @@ stages:
     include:
       - local: '.gitlab/custom-jobs-and-variables.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: 'v2024.07.0'
+        ref: 'v2025.06.0'
         file: 'pipelines/${CI_MACHINE}.yml'
-      - local: '.gitlab/jobs/ruby-performance.yml'
+      - local: '.gitlab/jobs/performances.yml'
     strategy: depend
     forward:
       pipeline_variables: true
@@ -101,7 +101,7 @@ include:
     file: 'id_tokens.yml'
   # [Optional] checks preliminary to running the actual CI test
   - project: 'radiuss/radiuss-shared-ci'
-    ref: 'v2024.07.0'
+    ref: 'v2025.06.0'
     file: 'utilities/preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'

--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -12,15 +12,15 @@ variables:
 # named so that we are sure to retrieve it and avoid collisions.
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
 
-# Ruby
+# Dane
 # Arguments for top level allocation
-  RUBY_SHARED_ALLOC: "--exclusive --reservation=ci --time=15 --nodes=1"
+  DANE_SHARED_ALLOC: "--exclusive --reservation=ci --time=15 --nodes=1"
 # Arguments for job level allocation
-  RUBY_JOB_ALLOC: "--reservation=ci --overlap --nodes=1"
-# Project specific variants for ruby
-  PROJECT_RUBY_VARIANTS: "+test"
-# Project specific deps for ruby
-  PROJECT_RUBY_DEPS: ""
+  DANE_JOB_ALLOC: "--reservation=ci --overlap --nodes=1"
+# Project specific variants for dane
+  PROJECT_DANE_VARIANTS: "+test"
+# Project specific deps for dane
+  PROJECT_DANE_DEPS: ""
 
 # Tioga
 # Arguments for top level allocation

--- a/.gitlab/jobs/dane.yml
+++ b/.gitlab/jobs/dane.yml
@@ -6,7 +6,7 @@
 ###############################################################################
 
 # Override reproducer section to define project specific variables.
-.ruby_reproducer_vars:
+.dane_reproducer_vars:
   script:
     - !reference [.reproducer_vars, script]
 
@@ -15,19 +15,19 @@
 ########################
 oneapi_2023_2_1:
   variables:
-    ON_RUBY: "OFF"
-  extends: .job_on_ruby
+    ON_DANE: "OFF"
+  extends: .job_on_dane
 
 # Force mvapich2 to be built with gcc
 gcc_10_3_1:
   variables:
-    SPEC: "${PROJECT_RUBY_VARIANTS} %gcc@=10.3.1 ${PROJECT_RUBY_DEPS} ^mvapich2%gcc@=10.3.1"
-  extends: .job_on_ruby
+    SPEC: "${PROJECT_DANE_VARIANTS} %gcc@=10.3.1 ${PROJECT_DANE_DEPS} ^mvapich2%gcc@=10.3.1"
+  extends: .job_on_dane
 
 ########################
 # Extra jobs
 ########################
 gcc_10_3_1_int64:
   variables:
-    SPEC: "${PROJECT_RUBY_VARIANTS} +int64 %gcc@=10.3.1 ${PROJECT_RUBY_DEPS} ^mvapich2%gcc@=10.3.1"
-  extends: .job_on_ruby
+    SPEC: "${PROJECT_DANE_VARIANTS} +int64 %gcc@=10.3.1 ${PROJECT_DANE_DEPS} ^mvapich2%gcc@=10.3.1"
+  extends: .job_on_dane

--- a/.gitlab/jobs/performances.yml
+++ b/.gitlab/jobs/performances.yml
@@ -7,7 +7,7 @@
 
 .performance_base_job:
   extends:
-    - .job_on_ruby
+    - .job_on_dane
     - .performance_job
   variables:
     PERFORMANCE_TESTS: "true"
@@ -15,4 +15,4 @@
 clang_14_0_6:
   extends: .performance_base_job
   variables:
-    SPEC: "${PROJECT_RUBY_VARIANTS} %clang@=14.0.6 ${PROJECT_RUBY_DEPS}"
+    SPEC: "${PROJECT_DANE_VARIANTS} %clang@=14.0.6 ${PROJECT_DANE_DEPS}"

--- a/.gitlab/subscribed-pipelines.yml
+++ b/.gitlab/subscribed-pipelines.yml
@@ -32,12 +32,12 @@ generate-job-lists:
     RADIUSS_JOBS_PATH: ".ci-scripts/radiuss-spack-configs/gitlab/radiuss-jobs"
     LOCAL_JOBS_PATH: ".gitlab/jobs"
   script:
-    - cat ${RADIUSS_JOBS_PATH}/ruby.yml ${LOCAL_JOBS_PATH}/ruby.yml > ruby-jobs.yml
+    - cat ${RADIUSS_JOBS_PATH}/dane.yml ${LOCAL_JOBS_PATH}/dane.yml > dane-jobs.yml
     - cat ${RADIUSS_JOBS_PATH}/lassen.yml ${LOCAL_JOBS_PATH}/lassen.yml > lassen-jobs.yml
     - cat ${RADIUSS_JOBS_PATH}/tioga.yml ${LOCAL_JOBS_PATH}/tioga.yml > tioga-jobs.yml
   artifacts:
     paths:
-      - ruby-jobs.yml
+      - dane-jobs.yml
       - lassen-jobs.yml
       - tioga-jobs.yml
 
@@ -46,16 +46,16 @@ generate-job-lists:
 # Comment the jobs for machines you don’t need.
 ###
 
-# RUBY
-ruby-up-check:
+# DANE
+dane-up-check:
   variables:
-    CI_MACHINE: "ruby"
+    CI_MACHINE: "dane"
   extends: [.machine-check]
 
-ruby-build-and-test:
+dane-build-and-test:
   variables:
-    CI_MACHINE: "ruby"
-  needs: [ruby-up-check, generate-job-lists]
+    CI_MACHINE: "dane"
+  needs: [dane-up-check, generate-job-lists]
   extends: [.build-and-test]
 
 # TIOGA
@@ -83,7 +83,7 @@ lassen-build-and-test:
   extends: [.build-and-test]
 
 # PERFORMANCE
-ruby-performance-test:
+dane-performance-test:
   variables:
-    CI_MACHINE: "ruby"
+    CI_MACHINE: "dane"
   extends: [.performance-test]


### PR DESCRIPTION
- Replace ruby with dane in CI jobs. Note this applies to the performance job as well, so that could cause a change in timings.
- Update radiuss-shared-ci ref