### PR TITLE
Update to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose build type" FORCE)
 endif()
 
-set(BLT_CXX_STD "c++14" CACHE STRING "Version of C++ standard")
-set(CMAKE_CXX_STANDARD 14)
+set(BLT_CXX_STD "c++17" CACHE STRING "Version of C++ standard")
+set(CMAKE_CXX_STANDARD 17)
 
 set(ENABLE_MPI ON CACHE BOOL "")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 set(BLT_CXX_STD "c++17" CACHE STRING "Version of C++ standard")
-set(CMAKE_CXX_STANDARD 17)
 
 set(ENABLE_MPI ON CACHE BOOL "")
 

--- a/docs/mkdocs/getting_started.md
+++ b/docs/mkdocs/getting_started.md
@@ -20,7 +20,7 @@ This automatically handles all dependencies including PETSc and MPI.
 - **PETSc** (Portable, Extensible Toolkit for Scientific Computation)
 - **MPI** implementation for parallel execution
 - **CMake** 3.23 or later
-- **C++ compiler** with C++14 support
+- **C++ compiler** with C++17 support
 
 **Steps:**
 


### PR DESCRIPTION
This PR sets C++17 as the minimal version. Other LLNL projects have recently also moved to 17, so this should be supported on various LC machines.