### PR TITLE
Improve GitHub benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -76,7 +76,7 @@ jobs:
         run: exit 1
 
   store-and-visualize-on-main:
-    # if: github.ref == 'refs/heads/main' # TODO uncomment before merging
+    if: github.ref == 'refs/heads/main'
     permissions:
       # Needed to push to gh-pages branch
       contents: write

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,8 +18,7 @@ jobs:
       # Needed to write PR check status
       checks: write
       # Need write for commit comments
-      pull-requests: write
-      contents: read
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,21 +11,26 @@ on:
         required: false
         default: 'Quandary benchmarks'
 
-permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-
 jobs:
-  store-and-visualize:
+  check-performance:
+    if: github.ref != 'refs/heads/main'
+    permissions:
+      # Needed to write PR check status
+      checks: write
+      # Need write for commit comments
+      pull-requests: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Find associated PR
         id: findpr
         run: |
+          echo "Looking for PR with head branch: ${{ github.ref_name }}"
+          gh pr list --head ${{ github.ref_name }} --json number,title
           PR_NUMBER=$(gh pr list --head ${{ github.ref_name }} --json number -q '.[0].number')
+          echo "Found PR number: $PR_NUMBER"
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +38,7 @@ jobs:
       - name: Decode benchmark data
         run: echo "${{ github.event.inputs.benchmark_data }}" | base64 -d > benchmark.json
 
-      - name: Store benchmark result
+      - name: Compare benchmark result
         id: benchmark
         continue-on-error: true
         uses: benchmark-action/github-action-benchmark@v1
@@ -41,25 +46,62 @@ jobs:
           tool: 'customSmallerIsBetter'
           output-file-path: benchmark.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
+          auto-push: false
+          save-data-file: false
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
           comment-always: true
+          comment-on-alert: true
+          summary-always: true
           fail-on-alert: true
           alert-threshold: '120%'
           max-items-in-chart: 100
 
       - name: Create Check for PRs
         if: steps.findpr.outputs.pr_number != ''
-        uses: LouisBrunner/checks-action@v1.6.1
+        uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Performance Benchmark
           sha: ${{ github.sha }}
           conclusion: ${{ steps.benchmark.outcome == 'success' && 'success' || 'failure' }}
           output: |
-            {"summary": "${{ steps.benchmark.outcome == 'success' && 'Performance check passed' || 'Performance regression detected!' }}"}
+            {
+              "title": "Performance Results",
+              "summary": "${{ steps.benchmark.outcome == 'success' && 'Performance check passed' || 'Performance regression detected!' }}",
+              "text_description": "See job summary for detailed benchmark results: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
 
       - name: Final status
         if: steps.benchmark.outcome != 'success'
         run: exit 1
+
+  store-and-visualize-on-main:
+    # if: github.ref == 'refs/heads/main' # TODO uncomment before merging
+    permissions:
+      # Needed to push to gh-pages branch
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Decode benchmark data
+        run: echo "${{ github.event.inputs.benchmark_data }}" | base64 -d > benchmark.json
+
+      - name: Store benchmark result
+        id: benchmark
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: ${{ github.event.inputs.benchmark_name }}
+          tool: 'customSmallerIsBetter'
+          output-file-path: benchmark.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          comment-always: false
+          comment-on-alert: false
+          summary-always: true
+          fail-on-alert: true
+          alert-threshold: '120%'
+          max-items-in-chart: 100


### PR DESCRIPTION
Improve GitHub benchmark workflow:
- separate PR check job from job that runs on main and pushes to the dashboard, which allows limiting the scope of the permissions on the PR job
- Update checkout action version and improve output from workflow
