### PR TITLE
Use fixed runner version in GitHub workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-24.04]
+        os: [macos-15, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     permissions:
       packages: write


### PR DESCRIPTION
Explicitly set macos-15 as GitHub runner instead of using latest