### PR TITLE
Fix CMakeLists for optional Slepsc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,7 @@ set_target_properties(
 # Optional: Sanity check
 option(SANITY_CHECK "Run sanity checks" OFF)
 if(SANITY_CHECK)
-    target_compile_options(quandary PRIVATE -DSANITY_CHECK)
+    target_compile_options(quandary_lib PUBLIC -DSANITY_CHECK)
 endif()
 
 # Optional: Link to SLEPC
@@ -43,8 +43,8 @@ option(WITH_SLEPC "Link to SLEPC" OFF)
 if(WITH_SLEPC)
     find_package(PkgConfig REQUIRED)
     pkg_search_module(SLEPC REQUIRED IMPORTED_TARGET SLEPc)
-    target_link_libraries(quandary PRIVATE PkgConfig::SLEPC)
-    target_compile_options(quandary PRIVATE -DWITH_SLEPC)
+    target_link_libraries(quandary_lib PUBLIC PkgConfig::SLEPC)
+    target_compile_options(quandary_lib PUBLIC -DWITH_SLEPC)
 endif()
 
 install(


### PR DESCRIPTION
Adding Slepc to quandary_lib rather than quandary target. Make it PUBLIC rather than PRIVATE.