### PR TITLE
Buffer trajectory data in output class, write after timestepping.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -255,7 +255,7 @@ int main(int argc,char **argv)
     std::vector<double> pt, qt;
     optimctx->getStartingPoint(xinit);
     if (mpirank_world == 0 && !quietmode) printf("\nEvaluating current controls ... \n");
-    output->writeControls(xinit, mastereq, ntime, dt);
+    output->writeControls(xinit, mastereq);
   }
 
   /* Output */

--- a/src/optimproblem.cpp
+++ b/src/optimproblem.cpp
@@ -536,7 +536,7 @@ void OptimProblem::getStartingPoint(Vec xinit){
   timestepper->mastereq->setControlAmplitudes(xinit);
   
   /* Write initial control functions to file */
-  output->writeControls(xinit, timestepper->mastereq, timestepper->ntime, timestepper->dt);
+  output->writeControls(xinit, timestepper->mastereq);
 
 }
 
@@ -610,7 +610,7 @@ PetscErrorCode TaoMonitor(Tao tao,void*ptr){
 
   /* Last iteration: Print solution, controls and trajectory data to files */
   if (lastIter) {
-    ctx->output->writeControls(params, ctx->timestepper->mastereq, ctx->timestepper->ntime, ctx->timestepper->dt);
+    ctx->output->writeControls(params, ctx->timestepper->mastereq);
 
     // do one last forward evaluation while writing trajectory files
     ctx->timestepper->writeTrajectoryDataFiles = true;

--- a/src/timestepper.cpp
+++ b/src/timestepper.cpp
@@ -94,9 +94,9 @@ Vec TimeStepper::getState(size_t tindex){
 
 Vec TimeStepper::solveODE(int initid, Vec rho_t0){
 
-  /* Open output files */
+  /* Prepare storage for trajectory output data */
   if (writeTrajectoryDataFiles) {
-    output->openTrajectoryDataFiles("rho", initid);
+    output->initTrajectoryData(initid, mastereq);
   }
 
   /* Set initial condition  */
@@ -131,7 +131,7 @@ Vec TimeStepper::solveODE(int initid, Vec rho_t0){
     /* store and write current state. */
     if (storeFWD) VecCopy(x, store_states[n]);
     if (writeTrajectoryDataFiles) {
-      output->writeTrajectoryDataFiles(n, tstart, x, mastereq);
+      output->evalTrajectoryData(n, tstart, x, mastereq);
     }
 
     /* Take one time step */
@@ -177,8 +177,8 @@ Vec TimeStepper::solveODE(int initid, Vec rho_t0){
 
   /* Write last time step and close files */
   if (writeTrajectoryDataFiles) {
-    output->writeTrajectoryDataFiles(ntime, ntime*dt, x, mastereq);
-    output->closeTrajectoryDataFiles();
+    output->evalTrajectoryData(ntime, ntime*dt, x, mastereq);
+    output->writeTrajectoryData();
   }
   
 


### PR DESCRIPTION
Rather than writing trajectory data at every time-step, this PR buffers the data in the output class and writes it to files only after the time stepping finishes. 

TODO:
* Estimate file sizes upfront and either create a warning or disable/reduce output frequency if files are getting too large. 