### PR TITLE
PETSc VecType fix for GPUs

### DIFF
--- a/src/mastereq.cpp
+++ b/src/mastereq.cpp
@@ -99,6 +99,12 @@ MasterEq::MasterEq(const Config& config, Oscillator** oscil_vec_, bool quietmode
   PetscInt localsize_x  = 2 * dim / mpisize_petsc;  // local size of state vector x=[u,v]
   MatCreateShell(PETSC_COMM_WORLD, localsize_x, localsize_x, globalsize_x, globalsize_x, (void**) &RHSctx, &RHS);
   MatSetOptionsPrefix(RHS, "system");
+  // PETSc creates MatShell work vectors using the Mat's VecType.
+  // Without this, they default to seq/mpi even with -vec_type kokkos (GPU), breaking AIJKokkos MatMult.
+  char vec_type_opt[128] = {0};
+  PetscBool vec_type_set = PETSC_FALSE;
+  PetscOptionsGetString(NULL, NULL, "-vec_type", vec_type_opt, sizeof(vec_type_opt), &vec_type_set);
+  if (vec_type_set) MatSetVecType(RHS, vec_type_opt);
   MatSetFromOptions(RHS); MatSetUp(RHS);
   MatAssemblyBegin(RHS,MAT_FINAL_ASSEMBLY); MatAssemblyEnd(RHS,MAT_FINAL_ASSEMBLY);
 


### PR DESCRIPTION
Set VecType for MatShell using PETSc VecType runtime options setting