### PR TITLE
Improve command line argument parsing

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -29,13 +29,22 @@ void printHelp() {
 ParsedArgs parseArguments(int argc, char** argv) {
   ParsedArgs args;
 
-  if (argc < 2 || std::string(argv[1]) == "--help") {
-    printHelp();
-    exit(0);
+  // Handle --help / --version anywhere on the command line, before any other
+  // validation, so they work regardless of position or config-file validity.
+  for (int i=1; i<argc; i++) {
+    std::string arg = argv[i];
+    if (arg == "--help") {
+      printHelp();
+      exit(0);
+    }
+    if (arg == "--version") {
+      printf("Quandary %s %s\n", QUANDARY_FULL_VERSION_STRING, QUANDARY_GIT_SHA);
+      exit(0);
+    }
   }
 
-  if (std::string(argv[1]) == "--version") {
-    printf("Quandary %s %s\n", QUANDARY_FULL_VERSION_STRING, QUANDARY_GIT_SHA);
+  if (argc < 2) {
+    printHelp();
     exit(0);
   }
 
@@ -52,13 +61,37 @@ ParsedArgs parseArguments(int argc, char** argv) {
 
   // Parse quiet mode and PETSc options flags
   std::string petsc_options;
+  std::vector<std::string> unrecognized;
   for (int i=2; i<argc; i++) {
     std::string arg = argv[i];
     if (arg == "--quiet") {
       args.quietmode = true;
-    } else if (arg == "--petsc-options" && i + 1 < argc) {
-      petsc_options = argv[++i];
+    } else if (arg == "--petsc-options") {
+      if (i + 1 < argc) {
+        petsc_options = argv[++i];
+      } else {
+        printf("\nERROR: --petsc-options requires a quoted argument, e.g.\n");
+        printf("    --petsc-options \"-log_view -tao_view\"\n\n");
+        exit(1);
+      }
+    } else {
+      unrecognized.push_back(arg);
     }
+  }
+
+  // Reject unknown arguments rather than silently ignoring them. A common
+  // mistake is forgetting the quotes around PETSc options, e.g.
+  //   --petsc-options -vec_type kokkos -mat_type aijkokkos
+  // which leaves every token after the first as an unrecognized argument
+  // (and passes a value-less option to PETSc).
+  if (!unrecognized.empty()) {
+    printf("\nERROR: Unrecognized argument(s):");
+    for (const auto& arg : unrecognized) printf(" %s", arg.c_str());
+    printf("\n");
+    printf("Hint: pass ALL PETSc/SLEPc options together inside quotes, e.g.\n");
+    printf("    --petsc-options \"-vec_type kokkos -mat_type aijkokkos -log_view\"\n");
+    printf("Run 'quandary --help' for usage.\n\n");
+    exit(1);
   }
 
   // Build PETSc argc/argv

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -79,11 +79,7 @@ ParsedArgs parseArguments(int argc, char** argv) {
     }
   }
 
-  // Reject unknown arguments rather than silently ignoring them. A common
-  // mistake is forgetting the quotes around PETSc options, e.g.
-  //   --petsc-options -vec_type kokkos -mat_type aijkokkos
-  // which leaves every token after the first as an unrecognized argument
-  // (and passes a value-less option to PETSc).
+  // Reject unknown arguments rather than silently ignoring them
   if (!unrecognized.empty()) {
     fprintf(stderr, "\nERROR: Unrecognized argument(s):");
     for (const auto& arg : unrecognized) fprintf(stderr, " %s", arg.c_str());

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -53,8 +53,8 @@ ParsedArgs parseArguments(int argc, char** argv) {
   // Validate config file exists and is readable
   std::ifstream test_file(args.config_filename);
   if (!test_file.good()) {
-    printf("\nERROR: Cannot open config file '%s'\n", args.config_filename.c_str());
-    printf("Please check that the file exists and is readable.\n\n");
+    fprintf(stderr, "\nERROR: Cannot open config file '%s'\n", args.config_filename.c_str());
+    fprintf(stderr, "Please check that the file exists and is readable.\n\n");
     exit(1);
   }
   test_file.close();
@@ -70,8 +70,8 @@ ParsedArgs parseArguments(int argc, char** argv) {
       if (i + 1 < argc) {
         petsc_options = argv[++i];
       } else {
-        printf("\nERROR: --petsc-options requires a quoted argument, e.g.\n");
-        printf("    --petsc-options \"-log_view -tao_view\"\n\n");
+        fprintf(stderr, "\nERROR: --petsc-options requires a quoted argument, e.g.\n");
+        fprintf(stderr, "    --petsc-options \"-log_view -tao_view\"\n\n");
         exit(1);
       }
     } else {
@@ -85,12 +85,12 @@ ParsedArgs parseArguments(int argc, char** argv) {
   // which leaves every token after the first as an unrecognized argument
   // (and passes a value-less option to PETSc).
   if (!unrecognized.empty()) {
-    printf("\nERROR: Unrecognized argument(s):");
-    for (const auto& arg : unrecognized) printf(" %s", arg.c_str());
-    printf("\n");
-    printf("Hint: pass ALL PETSc/SLEPc options together inside quotes, e.g.\n");
-    printf("    --petsc-options \"-vec_type kokkos -mat_type aijkokkos -log_view\"\n");
-    printf("Run 'quandary --help' for usage.\n\n");
+    fprintf(stderr, "\nERROR: Unrecognized argument(s):");
+    for (const auto& arg : unrecognized) fprintf(stderr, " %s", arg.c_str());
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Hint: pass ALL PETSc/SLEPc options together inside quotes, e.g.\n");
+    fprintf(stderr, "    --petsc-options \"-vec_type kokkos -mat_type aijkokkos -log_view\"\n");
+    fprintf(stderr, "Run 'quandary --help' for usage.\n\n");
     exit(1);
   }
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -12,4 +12,16 @@ if(ENABLE_TESTS)
     NAME test_tomlparser
     COMMAND test_tomlparser
   )
+
+  blt_add_executable(
+    NAME test_argparser
+    SOURCES test_argparser.cpp
+    DEPENDS_ON quandary_lib gtest
+    FOLDER tests
+  )
+
+  blt_add_test(
+    NAME test_argparser
+    COMMAND test_argparser
+  )
 endif()

--- a/tests/unit/test_argparser.cpp
+++ b/tests/unit/test_argparser.cpp
@@ -35,9 +35,8 @@ TEST_F(ArgParserTest, ParsesQuietAndQuotedPetscOptions) {
   EXPECT_EQ(args.petsc_tokens[1], "-tao_view");
 }
 
-// Forgetting the quotes leaves the value-tokens as unrecognized arguments
-// (the original crash: PETSc received a value-less -vec_type). This must
-// error out rather than silently dropping them.
+// Forgetting the quotes leaves the value-tokens as unrecognized arguments,
+// which must error out rather than being silently dropped.
 TEST_F(ArgParserTest, UnquotedPetscOptionsExitWithError) {
   EXPECT_EXIT(parse({"quandary", config, "--petsc-options", "-vec_type",
                      "kokkos", "-mat_type", "aijkokkos"}),

--- a/tests/unit/test_argparser.cpp
+++ b/tests/unit/test_argparser.cpp
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "util.hpp"
+
+// parseArguments() validates that the config file (argv[1]) exists before
+// parsing flags, so tests provide an empty, readable file as the config.
+class ArgParserTest : public ::testing::Test {
+ protected:
+  const std::string config = "argparser_test.cfg";
+
+  void SetUp() override { std::ofstream(config).close(); }
+  void TearDown() override { std::remove(config.c_str()); }
+
+  // Calls parseArguments() with argv built from the given tokens.
+  ParsedArgs parse(std::vector<std::string> tokens) {
+    std::vector<char*> argv;
+    for (auto& tok : tokens) argv.push_back(const_cast<char*>(tok.c_str()));
+    return parseArguments(static_cast<int>(argv.size()), argv.data());
+  }
+};
+
+TEST_F(ArgParserTest, ParsesQuietAndQuotedPetscOptions) {
+  // The shell strips the quotes the user types and passes the quoted options as
+  // a SINGLE argv element containing a space ("-log_view -tao_view"), which
+  // parseArguments then splits on whitespace. We reproduce that here directly.
+  ParsedArgs args = parse({"quandary", config, "--quiet", "--petsc-options",
+                           "-log_view -tao_view"});
+  EXPECT_TRUE(args.quietmode);
+  ASSERT_EQ(args.petsc_tokens.size(), 2);
+  EXPECT_EQ(args.petsc_tokens[0], "-log_view");
+  EXPECT_EQ(args.petsc_tokens[1], "-tao_view");
+}
+
+// Forgetting the quotes leaves the value-tokens as unrecognized arguments
+// (the original crash: PETSc received a value-less -vec_type). This must
+// error out rather than silently dropping them.
+TEST_F(ArgParserTest, UnquotedPetscOptionsExitWithError) {
+  EXPECT_EXIT(parse({"quandary", config, "--petsc-options", "-vec_type",
+                     "kokkos", "-mat_type", "aijkokkos"}),
+              ::testing::ExitedWithCode(1), "");
+}
+
+TEST_F(ArgParserTest, UnknownFlagExitsWithError) {
+  EXPECT_EXIT(parse({"quandary", config, "--bogus"}),
+              ::testing::ExitedWithCode(1), "");
+}
+
+TEST_F(ArgParserTest, PetscOptionsMissingValueExitsWithError) {
+  EXPECT_EXIT(parse({"quandary", config, "--petsc-options"}),
+              ::testing::ExitedWithCode(1), "");
+}
+
+// --help and --version must work in any position (exit 0), not be treated as
+// unrecognized arguments when they follow the config file.
+TEST_F(ArgParserTest, HelpAfterConfigExitsZero) {
+  EXPECT_EXIT(parse({"quandary", config, "--help"}),
+              ::testing::ExitedWithCode(0), "");
+}
+
+TEST_F(ArgParserTest, VersionAfterConfigExitsZero) {
+  EXPECT_EXIT(parse({"quandary", config, "--version"}),
+              ::testing::ExitedWithCode(0), "");
+}

--- a/tests/unit/test_argparser.cpp
+++ b/tests/unit/test_argparser.cpp
@@ -41,17 +41,17 @@ TEST_F(ArgParserTest, ParsesQuietAndQuotedPetscOptions) {
 TEST_F(ArgParserTest, UnquotedPetscOptionsExitWithError) {
   EXPECT_EXIT(parse({"quandary", config, "--petsc-options", "-vec_type",
                      "kokkos", "-mat_type", "aijkokkos"}),
-              ::testing::ExitedWithCode(1), "");
+              ::testing::ExitedWithCode(1), "Unrecognized argument");
 }
 
 TEST_F(ArgParserTest, UnknownFlagExitsWithError) {
   EXPECT_EXIT(parse({"quandary", config, "--bogus"}),
-              ::testing::ExitedWithCode(1), "");
+              ::testing::ExitedWithCode(1), "Unrecognized argument");
 }
 
 TEST_F(ArgParserTest, PetscOptionsMissingValueExitsWithError) {
   EXPECT_EXIT(parse({"quandary", config, "--petsc-options"}),
-              ::testing::ExitedWithCode(1), "");
+              ::testing::ExitedWithCode(1), "requires a quoted argument");
 }
 
 // --help and --version must work in any position (exit 0), not be treated as


### PR DESCRIPTION
- Improve CLI for PETSc options. For something like `quandary ./config.toml --petsc-options -vec_type kokkos -mat_type aijkokkos -log_view -log_summary` it now returns error and hint to quote arguments, where previously the options after the first space in the petsc options would be silently ignored and possibly cause a PETSc crash
- Allow `--help` or `--version` at any position for convience (allow `./quandary config.toml --help`)
- Any unknown arguments result in error and helpful message
- Print errors to stderr instead of stdout
- Add unit tests for CLI parsing