### PR TITLE
CI: Initial HubCast config file

### DIFF
--- a/.github/hubcast.yml
+++ b/.github/hubcast.yml
@@ -1,0 +1,16 @@
+Repo:
+  dest_org: quantum1
+
+  dest_name: quandary
+
+  check_name: gitlab-ci
+
+  check_types: [pipeline, child-pipelines]
+
+  delete_closed: true
+
+  sync_drafts: true
+
+  sync_drafts_msg: true
+
+  create_mr: false

--- a/.github/hubcast.yml
+++ b/.github/hubcast.yml
@@ -5,7 +5,7 @@ Repo:
 
   check_name: gitlab-ci
 
-  check_types: [pipeline, child-pipelines]
+  check_types: [pipeline, child-pipelines, jobs]
 
   delete_closed: true
 


### PR DESCRIPTION
Changes how the CI handles mirroring from GitHub to GitLab.

See also: https://github.com/llnl/hubcast/blob/main/docs/guide-user.md, https://dev.llnl.gov/software-engineering/hubcast/#overview