### PR TITLE
Fix init amplitude

### DIFF
--- a/quandary.py
+++ b/quandary.py
@@ -764,12 +764,12 @@ class Quandary:
         else:
             init_type = "random" if self.randomize_init_ctrl else "constant"
             if len(self.initctrl_MHz) <= 1:
-                initamp = self.initctrl_MHz[0] / 1000.0 / np.sqrt(2) / len(self.carrier_frequency[0])
+                initamp = self.initctrl_MHz[0] / 1000.0  # scale to GHz
                 lines.append(f"initialization = {{ type = {_toml_str(init_type)}, amplitude = {initamp} }}")
             else:
                 lines.append("initialization = [")
                 for iosc in range(len(self.initctrl_MHz)):
-                    initamp = self.initctrl_MHz[iosc] / 1000.0 / np.sqrt(2) / len(self.carrier_frequency[iosc])
+                    initamp = self.initctrl_MHz[iosc] / 1000.0  # scale to GHz
                     lines.append(f"  {{ subsystem = {iosc}, type = {_toml_str(init_type)}, amplitude = {initamp} }},")
                 lines.append("]")
 

--- a/src/oscillator.cpp
+++ b/src/oscillator.cpp
@@ -116,8 +116,9 @@ Oscillator::Oscillator(const Config& config, size_t id, std::mt19937 rand_engine
 
     } else if (controlinitialization.type == ControlInitializationType::CONSTANT || controlinitialization.type == ControlInitializationType::RANDOM) { 
 
-      // Note, the config amplitude is multiplied by 2pi here!!
+      // Note, the config amplitude is assumed to be in frequency domain, multiply by 2PI here. 
       double initval = controlinitialization.amplitude.value()*2.0*M_PI;
+      initval = initval / getNCarrierfrequencies(); // scale down by number of carrier frequencies
       
       for (size_t f = 0; f<carrier_freq.size(); f++) {
         for (int i=0; i<basisfunctions[iseg]->getNparams(); i++){

--- a/tests/python/test_example_cnot.py
+++ b/tests/python/test_example_cnot.py
@@ -138,6 +138,7 @@ def test_example_cnot(mpi_exec, tmp_path, request):
         rotfreq=rotfreq,
         T=T,
         targetgate=unitary,
+        initctrl_MHz=10.0 /np.sqrt(2),
         verbose=False,
         rand_seed=1234,
     )

--- a/tests/python/test_example_cnot_const_init_ctrl.py
+++ b/tests/python/test_example_cnot_const_init_ctrl.py
@@ -139,7 +139,7 @@ def test_example_cnot_const_init_ctrl(mpi_exec, tmp_path, request):
         T=T,
         targetgate=unitary,
         verbose=False,
-        initctrl_MHz=100.0,
+        initctrl_MHz=100.0 / np.sqrt(2),
         randomize_init_ctrl=False,
     )
 

--- a/tests/python/test_example_cnot_withguardlevels.py
+++ b/tests/python/test_example_cnot_withguardlevels.py
@@ -150,6 +150,7 @@ def test_example_cnot_withguardlevels(mpi_exec, tmp_path, request):
         Jkl=Jkl,
         rotfreq=rotfreq,
         T=T,
+        initctrl_MHz=10.0 / np.sqrt(2),
         targetgate=unitary,
         verbose=False,
         rand_seed=1234,

--- a/tests/python/test_example_piecewise_constant_controls.py
+++ b/tests/python/test_example_piecewise_constant_controls.py
@@ -149,6 +149,7 @@ def test_example_piecewise_constant_controls(mpi_exec, tmp_path, request):
         verbose=False,
         rand_seed=1234,
         spline_order=spline_order,
+        initctrl_MHz=10.0 /np.sqrt(2),
         nsplines=nsplines,
         gamma_variation=gamma_variation,
         control_enforce_BC=control_enforce_BC

--- a/tests/python/test_example_qft.py
+++ b/tests/python/test_example_qft.py
@@ -325,6 +325,7 @@ def test_example_qft(mpi_exec, tmp_path, request):
         verbose=False,
         rand_seed=1234,
         maxctrl_MHz=maxctrl_MHz,
+        initctrl_MHz=10.0 /np.sqrt(2),
         cw_amp_thres=cw_amp_thres,
         cw_prox_thres=cw_prox_thres,
         gamma_energy=gamma_energy,

--- a/tests/python/test_example_state_to_state.py
+++ b/tests/python/test_example_state_to_state.py
@@ -70,6 +70,7 @@ def test_example_state_to_state(mpi_exec, tmp_path, request):
         maxctrl_MHz=maxctrl_MHz,
         initialcondition=initialcondition,
         targetstate=targetstate,
+        initctrl_MHz=10.0 /np.sqrt(2),
         T=T,
         tol_infidelity=1e-5,
         rand_seed=4321,

--- a/tests/python/test_example_swap02.py
+++ b/tests/python/test_example_swap02.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from quandary import Quandary
+import numpy as np
 from utils import assert_results_equal
 
 # Mark all tests in this file as regression tests
@@ -82,6 +83,7 @@ def test_example_swap02(mpi_exec, tmp_path, request):
         freq01=freq01,
         selfkerr=selfkerr,
         maxctrl_MHz=maxctrl_MHz,
+        initctrl_MHz=10.0 /np.sqrt(2),
         targetgate=unitary,
         T=T,
         rand_seed=1234,

--- a/tests/python/test_example_swap12.py
+++ b/tests/python/test_example_swap12.py
@@ -140,6 +140,7 @@ def test_example_swap12(mpi_exec, tmp_path, request):
         T=T,
         maxctrl_MHz=maxctrl_MHz,
         targetgate=unitary,
+        initctrl_MHz=10.0 /np.sqrt(2),
         verbose=False,
         rand_seed=1234,
     )

--- a/tests/regression/AxC/AxC.toml
+++ b/tests/regression/AxC/AxC.toml
@@ -17,8 +17,8 @@ carrier_frequency = [
   { subsystem = 1, value = [0.0, 1.176] }
 ]
 initialization = [
-  { subsystem = 0, type = "constant", amplitude = 5.0 },
-  { subsystem = 1, type = "constant", amplitude = 1.0 }
+  { subsystem = 0, type = "constant", amplitude = 15.0 },
+  { subsystem = 1, type = "constant", amplitude = 2.0 }
 ]
 amplitude_bound = [25.0, 100.0]
 zero_boundary_condition = true

--- a/tests/regression/AxC_grad/AxC_grad.toml
+++ b/tests/regression/AxC_grad/AxC_grad.toml
@@ -17,8 +17,8 @@ carrier_frequency = [
   { subsystem = 1, value = [0.0, 1.176] }
 ]
 initialization = [
-  { subsystem = 0, type = "constant", amplitude = 5.0 },
-  { subsystem = 1, type = "constant", amplitude = 1.0 }
+  { subsystem = 0, type = "constant", amplitude = 15.0 },
+  { subsystem = 1, type = "constant", amplitude = 2.0 }
 ]
 amplitude_bound = [25.0, 100.0]
 zero_boundary_condition = true

--- a/tests/regression/AxC_grad_initBasis0/AxC_grad_initBasis0.toml
+++ b/tests/regression/AxC_grad_initBasis0/AxC_grad_initBasis0.toml
@@ -17,8 +17,8 @@ carrier_frequency = [
   { subsystem = 1, value = [0.0, 1.176] }
 ]
 initialization = [
-  { subsystem = 0, type = "constant", amplitude = 5.0 },
-  { subsystem = 1, type = "constant", amplitude = 1.0 }
+  { subsystem = 0, type = "constant", amplitude = 15.0 },
+  { subsystem = 1, type = "constant", amplitude = 2.0 }
 ]
 amplitude_bound = [25.0, 100.0]
 zero_boundary_condition = true

--- a/tests/regression/AxC_grad_schroedinger/AxC_grad_schroedinger.toml
+++ b/tests/regression/AxC_grad_schroedinger/AxC_grad_schroedinger.toml
@@ -16,8 +16,8 @@ carrier_frequency = [
   { subsystem = 1, value = [0.0, 1.176] }
 ]
 initialization = [
-  { subsystem = 0, type = "constant", amplitude = 5.0 },
-  { subsystem = 1, type = "constant", amplitude = 1.0 }
+  { subsystem = 0, type = "constant", amplitude = 15.0 },
+  { subsystem = 1, type = "constant", amplitude = 2.0 }
 ]
 amplitude_bound = [25.0, 100.0]
 zero_boundary_condition = true

--- a/tests/regression/AxC_initDiag0/AxC_initDiag0.toml
+++ b/tests/regression/AxC_initDiag0/AxC_initDiag0.toml
@@ -16,8 +16,8 @@ carrier_frequency = [
   { subsystem = 1, value = [0.0, 1.176] }
 ]
 initialization = [
-  { subsystem = 0, type = "constant", amplitude = 5.0 },
-  { subsystem = 1, type = "constant", amplitude = 1.0 }
+  { subsystem = 0, type = "constant", amplitude = 15.0 },
+  { subsystem = 1, type = "constant", amplitude = 2.0 }
 ]
 amplitude_bound = [25.0, 100.0]
 zero_boundary_condition = true

--- a/tests/regression/AxC_initEnsemble/AxC_initEnsemble.toml
+++ b/tests/regression/AxC_initEnsemble/AxC_initEnsemble.toml
@@ -16,8 +16,8 @@ carrier_frequency = [
   { subsystem = 1, value = [0.0, 1.176] }
 ]
 initialization = [
-  { subsystem = 0, type = "constant", amplitude = 5.0 },
-  { subsystem = 1, type = "constant", amplitude = 1.0 }
+  { subsystem = 0, type = "constant", amplitude = 15.0 },
+  { subsystem = 1, type = "constant", amplitude = 2.0 }
 ]
 amplitude_bound = [25.0, 100.0]
 zero_boundary_condition = true

--- a/tests/regression/AxC_initFile/AxC_initFile.toml
+++ b/tests/regression/AxC_initFile/AxC_initFile.toml
@@ -16,8 +16,8 @@ carrier_frequency = [
   { subsystem = 1, value = [0.0, 1.176] }
 ]
 initialization = [
-  { subsystem = 0, type = "constant", amplitude = 5.0 },
-  { subsystem = 1, type = "constant", amplitude = 1.0 }
+  { subsystem = 0, type = "constant", amplitude = 15.0 },
+  { subsystem = 1, type = "constant", amplitude = 2.0 }
 ]
 amplitude_bound = [25.0, 100.0]
 zero_boundary_condition = true

--- a/tests/regression/cnot/cnot.toml
+++ b/tests/regression/cnot/cnot.toml
@@ -15,7 +15,7 @@ carrier_frequency = [
   { subsystem = 0, value = [0.0, -0.2198, -0.1] },
   { subsystem = 1, value = [0.0, -0.2252, -0.1] }
 ]
-initialization = { type = "constant", amplitude = 0.005 }
+initialization = { type = "constant", amplitude = 0.015 }
 amplitude_bound = 0.008
 zero_boundary_condition = false
 

--- a/tests/regression/cnot_fromfile/cnot_fromfile.toml
+++ b/tests/regression/cnot_fromfile/cnot_fromfile.toml
@@ -16,7 +16,7 @@ carrier_frequency = [
   {subsystem = 0, value = [0, -0.2198, -0.10000000000000001]},
   {subsystem = 1, value = [0, -0.22520000000000001, -0.10000000000000001]}
 ]
-initialization = {type = "constant", amplitude = 0.005 }
+initialization = {type = "constant", amplitude = 0.015 }
 amplitude_bound = 0.008
 zero_boundary_condition = false
 

--- a/tests/regression/nlevels_4_4_4_4/nlevels_4_4_4_4.toml
+++ b/tests/regression/nlevels_4_4_4_4/nlevels_4_4_4_4.toml
@@ -12,7 +12,7 @@ initial_condition = {type = "state", levels = [1, 0, 0, 0]}
 [control]
 parameterization = { type = "spline", num = 15 }
 carrier_frequency = [0.0, -0.2, -0.001]
-initialization = { type = "constant", amplitude = 0.005 }
+initialization = { type = "constant", amplitude = 0.015 }
 amplitude_bound = 0.008
 zero_boundary_condition = false
 


### PR DESCRIPTION
Move scaling of the initial control amplitude by the number of carrier waves into the C++ code, rather than in the python code. 