### PR TITLE
Bugfix: Lower tolerance for testing whether t0 <= time <- tfinal.

### DIFF
--- a/src/oscillator.cpp
+++ b/src/oscillator.cpp
@@ -4,7 +4,7 @@
 #include "mpi_logger.hpp"
 #include <stdexcept>
 
-const double TOLERANCE = 1e-13; // Tolerance for avoiding numerical precision issues when comparing floating point numbers in evalControl.
+const double TOLERANCE = 1e-10; // Tolerance for avoiding numerical precision issues when comparing floating point numbers in evalControl.
 
 Oscillator::Oscillator(){
   nlevels = 0;


### PR DESCRIPTION
Previous tolerance 1e-13 was too tight and could not catch machine precision differences in dt.