### PR TITLE
Nanobind python interface debug subprocess runs

### DIFF
--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -515,16 +515,24 @@ def _run_subprocess(
             quiet_flag,
         ]
 
+    # Run the subprocess from a deterministic working directory.
+    # Using the config directory avoids failures when the parent process
+    # has a different cwd than an interactive shell session.
+    subprocess_cwd = os.path.dirname(config_file)
+    if working_dir != ".":
+        subprocess_cwd = os.path.abspath(working_dir)
+
     # Run the subprocess
     if total_cores <= 1:
         logger.info("Spawning single-process subprocess without MPI launcher")
     else:
         logger.info(f"Spawning subprocess with {total_cores} processes using {mpi_exec}")
     logger.debug(f"Subprocess command: {shlex.join(cmd)}")
+    logger.debug(f"Subprocess cwd: {subprocess_cwd}")
     capture_output = quiet
     result = subprocess.run(
         cmd,
-        cwd=working_dir,
+        cwd=subprocess_cwd,
         stdout=subprocess.PIPE if capture_output else None,
         stderr=subprocess.PIPE if capture_output else None,
         text=True,

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -290,6 +290,10 @@ def evaluate_controls(
 
 def _is_interactive():
     """Detect if running in an interactive Python session (Jupyter, IPython, or plain REPL)."""
+    # python -i script.py sets this flag during script execution.
+    if sys.flags.interactive:
+        return True
+
     # Check for IPython/Jupyter
     try:
         from IPython import get_ipython
@@ -400,12 +404,10 @@ def _run(
     comm = MPI.COMM_WORLD
     size = comm.Get_size()
 
-    # if _is_interactive():
-    if True:
+    if _is_interactive():
         # In interactive environment without MPI, spawn subprocess with MPI launcher for better performance
         if max_n_procs is None:
-            #max_n_procs = 4  # Default to 4 processes if not specified
-            max_n_procs = 2  # Default to 4 processes if not specified
+            max_n_procs = 4  # Default to 4 processes if not specified
         return _run_subprocess(
             config_input=config_input,
             max_n_procs=max_n_procs,

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -400,10 +400,12 @@ def _run(
     comm = MPI.COMM_WORLD
     size = comm.Get_size()
 
-    if _is_interactive():
+    # if _is_interactive():
+    if True:
         # In interactive environment without MPI, spawn subprocess with MPI launcher for better performance
         if max_n_procs is None:
-            max_n_procs = 4  # Default to 4 processes if not specified
+            #max_n_procs = 4  # Default to 4 processes if not specified
+            max_n_procs = 1  # Default to 4 processes if not specified
         return _run_subprocess(
             config_input=config_input,
             max_n_procs=max_n_procs,

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -11,7 +11,6 @@ MPI Lifecycle Management:
 from __future__ import annotations
 import logging
 import os
-import glob
 import shlex
 import subprocess
 import sys
@@ -486,59 +485,25 @@ def _run_subprocess(
     with open(config_file, "w") as f:
         f.write(toml_content)
 
-    # Create a small launcher script instead of using `python -c`.
-    # Some MPI launchers are sensitive to `-c` payload parsing.
-    launcher_script = os.path.abspath(
-        os.path.join(validated_config.output_directory, "_quandary_run_from_file.py")
-    )
-    launcher_code = (
-        "import os\n"
-        "import sys\n"
-        "import traceback\n"
-        "from quandary.new import run_from_file\n"
-        "rank = os.environ.get('OMPI_COMM_WORLD_RANK', os.environ.get('PMI_RANK', '?'))\n"
-        "quiet = bool(int(sys.argv[2]))\n"
-        "log_file = os.path.join(sys.argv[3], f'_quandary_launcher_rank_{rank}.log')\n"
-        "def _log(msg):\n"
-        "    with open(log_file, 'a') as _f:\n"
-        "        _f.write(msg + '\\n')\n"
-        "_log(f'start cwd={os.getcwd()} config={sys.argv[1]} quiet={quiet}')\n"
-        "print(f'[quandary-launcher rank={rank}] start cwd={os.getcwd()} config={sys.argv[1]} quiet={quiet}', file=sys.stderr, flush=True)\n"
-        "try:\n"
-        "    rc = run_from_file(sys.argv[1], quiet=quiet)\n"
-        "    _log(f'run_from_file returned {rc}')\n"
-        "    if rc not in (None, 0):\n"
-        "        print(f'[quandary-launcher rank={rank}] run_from_file return code {rc}', file=sys.stderr, flush=True)\n"
-        "        _log(f'nonzero return code {rc}')\n"
-        "        sys.exit(int(rc))\n"
-        "    _log('finished')\n"
-        "    print(f'[quandary-launcher rank={rank}] finished', file=sys.stderr, flush=True)\n"
-        "except Exception:\n"
-        "    _log('exception')\n"
-        "    _log(traceback.format_exc())\n"
-        "    print(f'[quandary-launcher rank={rank}] exception', file=sys.stderr, flush=True)\n"
-        "    traceback.print_exc()\n"
-        "    raise\n"
-    )
-    with open(launcher_script, "w") as f:
-        f.write(launcher_code)
-
+    # Python code to run Quandary from the TOML file.
+    # Dynamic values are passed via argv to avoid quoting edge cases.
+    python_code = "import sys; from quandary.new import run_from_file; run_from_file(sys.argv[1], quiet=bool(int(sys.argv[2])))"
     quiet_flag = "1" if quiet else "0"
 
     # Build command: bypass MPI launcher for single-process execution.
     # Some remote environments restrict mpirun even for -np 1.
     if total_cores <= 1:
-        cmd = [python_exec, launcher_script, config_file, quiet_flag, validated_config.output_directory]
+        cmd = [python_exec, "-c", python_code, config_file, quiet_flag]
     else:
         cmd = [
             mpi_exec,
             nproc_flag,
             str(total_cores),
             python_exec,
-            launcher_script,
+            "-c",
+            python_code,
             config_file,
             quiet_flag,
-            validated_config.output_directory,
         ]
 
     # Default subprocess cwd to caller's cwd (working_dir=".").
@@ -591,9 +556,6 @@ def _run_subprocess(
             print(result.stderr, end="", file=sys.stderr)
 
     if result.returncode != 0:
-        launcher_logs = sorted(
-            glob.glob(os.path.join(validated_config.output_directory, "_quandary_launcher_rank_*.log"))
-        )
         message_lines = [
             f"Quandary failed with return code {result.returncode}.",
             f"Command: {shlex.join(cmd)}",
@@ -602,23 +564,6 @@ def _run_subprocess(
         if removed_mpi_env:
             message_lines.append(
                 "Removed MPI env vars for child launch:\n" + "\n".join(removed_mpi_env)
-            )
-        if launcher_logs:
-            message_lines.append("Launcher logs found:\n" + "\n".join(launcher_logs))
-            log_snippets = []
-            for log_path in launcher_logs:
-                try:
-                    with open(log_path, "r") as f:
-                        content = f.read().strip()
-                    if content:
-                        log_snippets.append(f"{log_path}:\n{content}")
-                except OSError:
-                    pass
-            if log_snippets:
-                message_lines.append("Launcher log contents:\n\n" + "\n\n".join(log_snippets))
-        else:
-            message_lines.append(
-                "No launcher log files were created. MPI likely failed before Python ranks executed."
             )
         if result.stderr and result.stderr.strip():
             message_lines.append(f"stderr:\n{result.stderr.strip()}")

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -405,7 +405,7 @@ def _run(
         # In interactive environment without MPI, spawn subprocess with MPI launcher for better performance
         if max_n_procs is None:
             #max_n_procs = 4  # Default to 4 processes if not specified
-            max_n_procs = 1  # Default to 4 processes if not specified
+            max_n_procs = 2  # Default to 4 processes if not specified
         return _run_subprocess(
             config_input=config_input,
             max_n_procs=max_n_procs,

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -485,18 +485,30 @@ def _run_subprocess(
     with open(config_file, "w") as f:
         f.write(toml_content)
 
-    # Python code to run Quandary from the TOML file
+    # Python code to run Quandary from the TOML file.
+    # Pass dynamic values through argv to avoid launcher/shell quoting issues.
     python_code = (
-        "from quandary.new import run_from_file; "
-        f"run_from_file({config_file!r}, quiet={quiet})"
+        "import sys\n"
+        "from quandary.new import run_from_file\n"
+        "run_from_file(sys.argv[1], quiet=bool(int(sys.argv[2])))"
     )
+    quiet_flag = "1" if quiet else "0"
 
     # Build command: bypass MPI launcher for single-process execution.
     # Some remote environments restrict mpirun even for -np 1.
     if total_cores <= 1:
-        cmd = [python_exec, "-c", python_code]
+        cmd = [python_exec, "-c", python_code, config_file, quiet_flag]
     else:
-        cmd = [mpi_exec, nproc_flag, str(total_cores), python_exec, "-c", python_code]
+        cmd = [
+            mpi_exec,
+            nproc_flag,
+            str(total_cores),
+            python_exec,
+            "-c",
+            python_code,
+            config_file,
+            quiet_flag,
+        ]
 
     # Run the subprocess
     if total_cores <= 1:

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -11,6 +11,7 @@ MPI Lifecycle Management:
 from __future__ import annotations
 import logging
 import os
+import shlex
 import subprocess
 import sys
 from typing import Optional
@@ -483,26 +484,41 @@ def _run_subprocess(
         f.write(toml_content)
 
     # Python code to run Quandary from the TOML file
-    python_code = f'from quandary.new import run_from_file; run_from_file("{config_file}", quiet={quiet})'
+    python_code = (
+        "from quandary.new import run_from_file; "
+        f"run_from_file({config_file!r}, quiet={quiet})"
+    )
 
     # Build the command with optimized core count
     cmd = [mpi_exec, nproc_flag, str(total_cores), python_exec, "-c", python_code]
 
     # Run the subprocess
     logger.info(f"Spawning subprocess with {total_cores} processes using {mpi_exec}")
-    logger.debug(f"Subprocess command: {' '.join(cmd)}")
+    logger.debug(f"Subprocess command: {shlex.join(cmd)}")
     result = subprocess.run(
         cmd,
         cwd=working_dir,
-        stdout=subprocess.PIPE if quiet else None,
+        stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
     )
 
-    if result.returncode != 0:
+    if not quiet:
+        if result.stdout:
+            print(result.stdout, end="")
         if result.stderr:
-            raise RuntimeError(f"Quandary failed:\n{result.stderr.strip()}")
-        raise RuntimeError("Quandary failed (see output above)")
+            print(result.stderr, end="", file=sys.stderr)
+
+    if result.returncode != 0:
+        message_lines = [
+            f"Quandary failed with return code {result.returncode}.",
+            f"Command: {shlex.join(cmd)}",
+        ]
+        if result.stderr and result.stderr.strip():
+            message_lines.append(f"stderr:\n{result.stderr.strip()}")
+        if result.stdout and result.stdout.strip():
+            message_lines.append(f"stdout:\n{result.stdout.strip()}")
+        raise RuntimeError("\n\n".join(message_lines))
 
     # Load results with validated config
     results = get_results(validated_config.output_directory)

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -11,6 +11,7 @@ MPI Lifecycle Management:
 from __future__ import annotations
 import logging
 import os
+import glob
 import shlex
 import subprocess
 import sys
@@ -497,14 +498,24 @@ def _run_subprocess(
         "from quandary.new import run_from_file\n"
         "rank = os.environ.get('OMPI_COMM_WORLD_RANK', os.environ.get('PMI_RANK', '?'))\n"
         "quiet = bool(int(sys.argv[2]))\n"
+        "log_file = os.path.join(sys.argv[3], f'_quandary_launcher_rank_{rank}.log')\n"
+        "def _log(msg):\n"
+        "    with open(log_file, 'a') as _f:\n"
+        "        _f.write(msg + '\\n')\n"
+        "_log(f'start cwd={os.getcwd()} config={sys.argv[1]} quiet={quiet}')\n"
         "print(f'[quandary-launcher rank={rank}] start cwd={os.getcwd()} config={sys.argv[1]} quiet={quiet}', file=sys.stderr, flush=True)\n"
         "try:\n"
         "    rc = run_from_file(sys.argv[1], quiet=quiet)\n"
+        "    _log(f'run_from_file returned {rc}')\n"
         "    if rc not in (None, 0):\n"
         "        print(f'[quandary-launcher rank={rank}] run_from_file return code {rc}', file=sys.stderr, flush=True)\n"
+        "        _log(f'nonzero return code {rc}')\n"
         "        sys.exit(int(rc))\n"
+        "    _log('finished')\n"
         "    print(f'[quandary-launcher rank={rank}] finished', file=sys.stderr, flush=True)\n"
         "except Exception:\n"
+        "    _log('exception')\n"
+        "    _log(traceback.format_exc())\n"
         "    print(f'[quandary-launcher rank={rank}] exception', file=sys.stderr, flush=True)\n"
         "    traceback.print_exc()\n"
         "    raise\n"
@@ -517,7 +528,7 @@ def _run_subprocess(
     # Build command: bypass MPI launcher for single-process execution.
     # Some remote environments restrict mpirun even for -np 1.
     if total_cores <= 1:
-        cmd = [python_exec, launcher_script, config_file, quiet_flag]
+        cmd = [python_exec, launcher_script, config_file, quiet_flag, validated_config.output_directory]
     else:
         cmd = [
             mpi_exec,
@@ -527,6 +538,7 @@ def _run_subprocess(
             launcher_script,
             config_file,
             quiet_flag,
+            validated_config.output_directory,
         ]
 
     # Default subprocess cwd to caller's cwd (working_dir=".").
@@ -557,11 +569,31 @@ def _run_subprocess(
             print(result.stderr, end="", file=sys.stderr)
 
     if result.returncode != 0:
+        launcher_logs = sorted(
+            glob.glob(os.path.join(validated_config.output_directory, "_quandary_launcher_rank_*.log"))
+        )
         message_lines = [
             f"Quandary failed with return code {result.returncode}.",
             f"Command: {shlex.join(cmd)}",
             f"CWD: {subprocess_cwd}",
         ]
+        if launcher_logs:
+            message_lines.append("Launcher logs found:\n" + "\n".join(launcher_logs))
+            log_snippets = []
+            for log_path in launcher_logs:
+                try:
+                    with open(log_path, "r") as f:
+                        content = f.read().strip()
+                    if content:
+                        log_snippets.append(f"{log_path}:\n{content}")
+                except OSError:
+                    pass
+            if log_snippets:
+                message_lines.append("Launcher log contents:\n\n" + "\n\n".join(log_snippets))
+        else:
+            message_lines.append(
+                "No launcher log files were created. MPI likely failed before Python ranks executed."
+            )
         if result.stderr and result.stderr.strip():
             message_lines.append(f"stderr:\n{result.stderr.strip()}")
         if result.stdout and result.stdout.strip():

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -491,9 +491,23 @@ def _run_subprocess(
         os.path.join(validated_config.output_directory, "_quandary_run_from_file.py")
     )
     launcher_code = (
+        "import os\n"
         "import sys\n"
+        "import traceback\n"
         "from quandary.new import run_from_file\n"
-        "run_from_file(sys.argv[1], quiet=bool(int(sys.argv[2])))\n"
+        "rank = os.environ.get('OMPI_COMM_WORLD_RANK', os.environ.get('PMI_RANK', '?'))\n"
+        "quiet = bool(int(sys.argv[2]))\n"
+        "print(f'[quandary-launcher rank={rank}] start cwd={os.getcwd()} config={sys.argv[1]} quiet={quiet}', file=sys.stderr, flush=True)\n"
+        "try:\n"
+        "    rc = run_from_file(sys.argv[1], quiet=quiet)\n"
+        "    if rc not in (None, 0):\n"
+        "        print(f'[quandary-launcher rank={rank}] run_from_file return code {rc}', file=sys.stderr, flush=True)\n"
+        "        sys.exit(int(rc))\n"
+        "    print(f'[quandary-launcher rank={rank}] finished', file=sys.stderr, flush=True)\n"
+        "except Exception:\n"
+        "    print(f'[quandary-launcher rank={rank}] exception', file=sys.stderr, flush=True)\n"
+        "    traceback.print_exc()\n"
+        "    raise\n"
     )
     with open(launcher_script, "w") as f:
         f.write(launcher_code)
@@ -515,12 +529,9 @@ def _run_subprocess(
             quiet_flag,
         ]
 
-    # Run the subprocess from a deterministic working directory.
-    # Using the config directory avoids failures when the parent process
-    # has a different cwd than an interactive shell session.
-    subprocess_cwd = os.path.dirname(config_file)
-    if working_dir != ".":
-        subprocess_cwd = os.path.abspath(working_dir)
+    # Default subprocess cwd to caller's cwd (working_dir=".").
+    # This preserves expected resolution for relative paths in config files.
+    subprocess_cwd = os.path.abspath(working_dir)
 
     # Run the subprocess
     if total_cores <= 1:
@@ -529,28 +540,32 @@ def _run_subprocess(
         logger.info(f"Spawning subprocess with {total_cores} processes using {mpi_exec}")
     logger.debug(f"Subprocess command: {shlex.join(cmd)}")
     logger.debug(f"Subprocess cwd: {subprocess_cwd}")
-    capture_output = quiet
+    # Always capture output so failures can include diagnostics.
+    capture_output = True
     result = subprocess.run(
         cmd,
         cwd=subprocess_cwd,
-        stdout=subprocess.PIPE if capture_output else None,
-        stderr=subprocess.PIPE if capture_output else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
     )
+
+    if not quiet:
+        if result.stdout:
+            print(result.stdout, end="")
+        if result.stderr:
+            print(result.stderr, end="", file=sys.stderr)
 
     if result.returncode != 0:
         message_lines = [
             f"Quandary failed with return code {result.returncode}.",
             f"Command: {shlex.join(cmd)}",
+            f"CWD: {subprocess_cwd}",
         ]
-        if capture_output and result.stderr and result.stderr.strip():
+        if result.stderr and result.stderr.strip():
             message_lines.append(f"stderr:\n{result.stderr.strip()}")
-        if capture_output and result.stdout and result.stdout.strip():
+        if result.stdout and result.stdout.strip():
             message_lines.append(f"stdout:\n{result.stdout.strip()}")
-        if not capture_output:
-            message_lines.append(
-                "Subprocess output was streamed directly to terminal (quiet=False); see logs above for details."
-            )
         raise RuntimeError("\n\n".join(message_lines))
 
     # Load results with validated config

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -487,11 +487,7 @@ def _run_subprocess(
 
     # Python code to run Quandary from the TOML file.
     # Pass dynamic values through argv to avoid launcher/shell quoting issues.
-    python_code = (
-        "import sys\n"
-        "from quandary.new import run_from_file\n"
-        "run_from_file(sys.argv[1], quiet=bool(int(sys.argv[2])))"
-    )
+    python_code = "import sys; from quandary.new import run_from_file; run_from_file(sys.argv[1], quiet=bool(int(sys.argv[2])))"
     quiet_flag = "1" if quiet else "0"
 
     # Build command: bypass MPI launcher for single-process execution.

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -493,23 +493,12 @@ def _run_subprocess(
     quiet_flag = "1" if quiet else "0"
 
     # Build command: 
-    cmd = [
-        mpi_exec,
-        nproc_flag,
-        str(total_cores),
-        python_exec,
-        "-c",
-        python_code,
-        config_file,
-        quiet_flag,
-    ]
+    cmd = [mpi_exec, nproc_flag, str(total_cores), python_exec, "-c", python_code, config_file, quiet_flag]
 
     # Default subprocess cwd to caller's cwd (working_dir=".").
-    # This preserves expected resolution for relative paths in config files.
     subprocess_cwd = os.path.abspath(working_dir)
 
-    # Sanitize inherited MPI runtime environment before launching a new MPI job.
-    # This avoids pre-launch failures when parent Python already has MPI-related vars.
+    # Sanitize inherited MPI runtime environment before launching a new MPI job. This avoids pre-launch failures when parent Python already has MPI-related vars.
     child_env = os.environ.copy()
     mpi_env_prefixes = (
         "OMPI_",
@@ -533,22 +522,14 @@ def _run_subprocess(
     logger.debug(f"Subprocess cwd: {subprocess_cwd}")
     if removed_mpi_env:
         logger.debug("Removed MPI env vars for child launch: %s", ", ".join(removed_mpi_env))
-    # Always capture output so failures can include diagnostics.
-    capture_output = True
     result = subprocess.run(
         cmd,
         cwd=subprocess_cwd,
         env=child_env,
-        stdout=subprocess.PIPE,
+        stdout=subprocess.PIPE if quiet else None,
         stderr=subprocess.PIPE,
         text=True,
     )
-
-    if not quiet:
-        if result.stdout:
-            print(result.stdout, end="")
-        if result.stderr:
-            print(result.stderr, end="", file=sys.stderr)
 
     if result.returncode != 0:
         message_lines = [

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -488,6 +488,7 @@ def _run_subprocess(
     # Python code to run Quandary from the TOML file.
     # Dynamic values are passed via argv to avoid quoting edge cases.
     python_code = "import sys; from quandary.new import run_from_file; run_from_file(sys.argv[1], quiet=bool(int(sys.argv[2])))"
+    quiet_flag = "1" if quiet else "0"
 
     # Build command: 
     cmd = [
@@ -498,7 +499,7 @@ def _run_subprocess(
         "-c",
         python_code,
         config_file,
-        quiet,
+        quiet_flag,
     ]
 
     # Default subprocess cwd to caller's cwd (working_dir=".").

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -489,11 +489,18 @@ def _run_subprocess(
         f"run_from_file({config_file!r}, quiet={quiet})"
     )
 
-    # Build the command with optimized core count
-    cmd = [mpi_exec, nproc_flag, str(total_cores), python_exec, "-c", python_code]
+    # Build command: bypass MPI launcher for single-process execution.
+    # Some remote environments restrict mpirun even for -np 1.
+    if total_cores <= 1:
+        cmd = [python_exec, "-c", python_code]
+    else:
+        cmd = [mpi_exec, nproc_flag, str(total_cores), python_exec, "-c", python_code]
 
     # Run the subprocess
-    logger.info(f"Spawning subprocess with {total_cores} processes using {mpi_exec}")
+    if total_cores <= 1:
+        logger.info("Spawning single-process subprocess without MPI launcher")
+    else:
+        logger.info(f"Spawning subprocess with {total_cores} processes using {mpi_exec}")
     logger.debug(f"Subprocess command: {shlex.join(cmd)}")
     capture_output = quiet
     result = subprocess.run(

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -495,29 +495,28 @@ def _run_subprocess(
     # Run the subprocess
     logger.info(f"Spawning subprocess with {total_cores} processes using {mpi_exec}")
     logger.debug(f"Subprocess command: {shlex.join(cmd)}")
+    capture_output = quiet
     result = subprocess.run(
         cmd,
         cwd=working_dir,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE if capture_output else None,
+        stderr=subprocess.PIPE if capture_output else None,
         text=True,
     )
-
-    if not quiet:
-        if result.stdout:
-            print(result.stdout, end="")
-        if result.stderr:
-            print(result.stderr, end="", file=sys.stderr)
 
     if result.returncode != 0:
         message_lines = [
             f"Quandary failed with return code {result.returncode}.",
             f"Command: {shlex.join(cmd)}",
         ]
-        if result.stderr and result.stderr.strip():
+        if capture_output and result.stderr and result.stderr.strip():
             message_lines.append(f"stderr:\n{result.stderr.strip()}")
-        if result.stdout and result.stdout.strip():
+        if capture_output and result.stdout and result.stdout.strip():
             message_lines.append(f"stdout:\n{result.stdout.strip()}")
+        if not capture_output:
+            message_lines.append(
+                "Subprocess output was streamed directly to terminal (quiet=False); see logs above for details."
+            )
         raise RuntimeError("\n\n".join(message_lines))
 
     # Load results with validated config

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -485,23 +485,32 @@ def _run_subprocess(
     with open(config_file, "w") as f:
         f.write(toml_content)
 
-    # Python code to run Quandary from the TOML file.
-    # Pass dynamic values through argv to avoid launcher/shell quoting issues.
-    python_code = "import sys; from quandary.new import run_from_file; run_from_file(sys.argv[1], quiet=bool(int(sys.argv[2])))"
+    # Create a small launcher script instead of using `python -c`.
+    # Some MPI launchers are sensitive to `-c` payload parsing.
+    launcher_script = os.path.abspath(
+        os.path.join(validated_config.output_directory, "_quandary_run_from_file.py")
+    )
+    launcher_code = (
+        "import sys\n"
+        "from quandary.new import run_from_file\n"
+        "run_from_file(sys.argv[1], quiet=bool(int(sys.argv[2])))\n"
+    )
+    with open(launcher_script, "w") as f:
+        f.write(launcher_code)
+
     quiet_flag = "1" if quiet else "0"
 
     # Build command: bypass MPI launcher for single-process execution.
     # Some remote environments restrict mpirun even for -np 1.
     if total_cores <= 1:
-        cmd = [python_exec, "-c", python_code, config_file, quiet_flag]
+        cmd = [python_exec, launcher_script, config_file, quiet_flag]
     else:
         cmd = [
             mpi_exec,
             nproc_flag,
             str(total_cores),
             python_exec,
-            "-c",
-            python_code,
+            launcher_script,
             config_file,
             quiet_flag,
         ]

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -488,23 +488,18 @@ def _run_subprocess(
     # Python code to run Quandary from the TOML file.
     # Dynamic values are passed via argv to avoid quoting edge cases.
     python_code = "import sys; from quandary.new import run_from_file; run_from_file(sys.argv[1], quiet=bool(int(sys.argv[2])))"
-    quiet_flag = "1" if quiet else "0"
 
-    # Build command: bypass MPI launcher for single-process execution.
-    # Some remote environments restrict mpirun even for -np 1.
-    if total_cores <= 1:
-        cmd = [python_exec, "-c", python_code, config_file, quiet_flag]
-    else:
-        cmd = [
-            mpi_exec,
-            nproc_flag,
-            str(total_cores),
-            python_exec,
-            "-c",
-            python_code,
-            config_file,
-            quiet_flag,
-        ]
+    # Build command: 
+    cmd = [
+        mpi_exec,
+        nproc_flag,
+        str(total_cores),
+        python_exec,
+        "-c",
+        python_code,
+        config_file,
+        quiet,
+    ]
 
     # Default subprocess cwd to caller's cwd (working_dir=".").
     # This preserves expected resolution for relative paths in config files.
@@ -530,10 +525,7 @@ def _run_subprocess(
         child_env.pop(k, None)
 
     # Run the subprocess
-    if total_cores <= 1:
-        logger.info("Spawning single-process subprocess without MPI launcher")
-    else:
-        logger.info(f"Spawning subprocess with {total_cores} processes using {mpi_exec}")
+    logger.info(f"Spawning subprocess with {total_cores} processes using {mpi_exec}")
     logger.debug(f"Subprocess command: {shlex.join(cmd)}")
     logger.debug(f"Subprocess cwd: {subprocess_cwd}")
     if removed_mpi_env:

--- a/python/quandary/new/run.py
+++ b/python/quandary/new/run.py
@@ -545,6 +545,25 @@ def _run_subprocess(
     # This preserves expected resolution for relative paths in config files.
     subprocess_cwd = os.path.abspath(working_dir)
 
+    # Sanitize inherited MPI runtime environment before launching a new MPI job.
+    # This avoids pre-launch failures when parent Python already has MPI-related vars.
+    child_env = os.environ.copy()
+    mpi_env_prefixes = (
+        "OMPI_",
+        "PMI_",
+        "PMIX_",
+        "MPI_",
+        "MPICH_",
+        "HYDRA_",
+        "I_MPI_",
+        "SLURM_MPI_",
+    )
+    removed_mpi_env = sorted(
+        k for k in list(child_env.keys()) if k.startswith(mpi_env_prefixes)
+    )
+    for k in removed_mpi_env:
+        child_env.pop(k, None)
+
     # Run the subprocess
     if total_cores <= 1:
         logger.info("Spawning single-process subprocess without MPI launcher")
@@ -552,11 +571,14 @@ def _run_subprocess(
         logger.info(f"Spawning subprocess with {total_cores} processes using {mpi_exec}")
     logger.debug(f"Subprocess command: {shlex.join(cmd)}")
     logger.debug(f"Subprocess cwd: {subprocess_cwd}")
+    if removed_mpi_env:
+        logger.debug("Removed MPI env vars for child launch: %s", ", ".join(removed_mpi_env))
     # Always capture output so failures can include diagnostics.
     capture_output = True
     result = subprocess.run(
         cmd,
         cwd=subprocess_cwd,
+        env=child_env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
@@ -577,6 +599,10 @@ def _run_subprocess(
             f"Command: {shlex.join(cmd)}",
             f"CWD: {subprocess_cwd}",
         ]
+        if removed_mpi_env:
+            message_lines.append(
+                "Removed MPI env vars for child launch:\n" + "\n".join(removed_mpi_env)
+            )
         if launcher_logs:
             message_lines.append("Launcher logs found:\n" + "\n".join(launcher_logs))
             log_snippets = []


### PR DESCRIPTION
* Minor fix: Run quandary via subprocesses if the python script is called with "-i"  (python -i example.py).

* More critically, executing quandary on subprocess was not working on my RedHat Fedora system. The issue might have been some MPI environment variables, which this PR removes. I debugged this with the help of Claude and I'm not entirely sure if it is correct and will work on other machines. I'm creating this PR to see if it builds and runs on other machines, and to get your feedback. 
@tdrwenski are tests run via subprocesses or via direct calls?