### PR TITLE
Speed up user docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,6 @@ markdown_extensions:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 theme:


### PR DESCRIPTION
Apparently this polyfill es6 wasn't needed (modern browsers already support this) and is slowing down the load of the user docs page.

See [here](https://github.com/llnl/quandary#building-user-guide-locally) if you want to test it locally.